### PR TITLE
Remember last selected filter on trips page

### DIFF
--- a/TripsPage.html
+++ b/TripsPage.html
@@ -472,7 +472,7 @@
 
   <script>
     const initialDate = <?= JSON.stringify(initialDate) ?>;
-    let currentFilter = 'time';
+    let currentFilter = localStorage.getItem('tripsFilter') || 'time';
     let currentLoadToken = 0;
     let allTrips = []; // stores raw trip data
     let searchQuery = ''; // stores current search
@@ -517,6 +517,7 @@
 
     function applyFilter(type) {
       currentFilter = type;
+      localStorage.setItem('tripsFilter', type);
       const dateInput = document.getElementById("trip-date");
 
       // Always hide filter menu


### PR DESCRIPTION
## Summary
- persist selected trips filter across sidebar sessions using `localStorage`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c7645ee08832fb14d987604e1ae3e