### PR TITLE
Add standing order data to log

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -72,6 +72,34 @@
         }
       }
 
+      function toggleStandingOrder() {
+        const box = document.getElementById("standing-order-checkbox");
+        const container = document.getElementById("standing-order-container");
+        container.style.display = box.checked ? "block" : "none";
+        if (box.checked) {
+          const rt = document.getElementById("return-trip-checkbox");
+          if (rt && !rt.checked) {
+            rt.checked = true;
+            toggleReturnTime();
+          }
+          const start = document.getElementById("standing-start-date");
+          if (start && !start.value) {
+            start.value = document.getElementById("trip-date").value;
+          }
+        }
+      }
+
+      function toggleCustomDays() {
+        const freq = document.getElementById("standing-frequency").value;
+        const days = document.getElementById("custom-days");
+        days.style.display = ["WEEKLY", "BIWEEKLY", "MONTHLY"].includes(freq)
+          ? "block"
+          : "none";
+        if (days.style.display === "none") {
+          days.querySelectorAll("input[type=checkbox]").forEach(c => (c.checked = false));
+        }
+      }
+
 
       function submitNewTrip() {
         document.getElementById("loading-overlay").style.display = "flex";
@@ -114,6 +142,17 @@
           notes: document.getElementById("trip-notes").value || ""
         };
 
+        const isStandingOrder = document.getElementById("standing-order-checkbox")?.checked;
+        if (isStandingOrder) {
+          trip.standing = {
+            frequency: document.getElementById("standing-frequency").value,
+            startDate: document.getElementById("standing-start-date").value,
+            endDate: document.getElementById("standing-end-date").value,
+            days: Array.from(document.querySelectorAll("#custom-days input:checked"))
+              .map(cb => cb.value)
+          };
+        }
+
         const isReturnTrip = document.getElementById("return-trip-checkbox")?.checked;
         const returnTime = document.getElementById("return-trip-time")?.value;
 
@@ -138,6 +177,9 @@
                 notes: (trip.notes || "") + " [RETURN TRIP]",
                 returnOf: trip.id
               };
+              if (isStandingOrder) {
+                returnTrip.standing = { ...trip.standing };
+              }
               google.script.run
                 .withSuccessHandler(() => {
                   document.getElementById("loading-overlay").style.display = "none";

--- a/Helpers.js
+++ b/Helpers.js
@@ -140,7 +140,8 @@ function tripObjectToRowArray(trip) {
     trip.notes || "",                  // Y
     "", "", "", "", "",                // Z - AD
     trip.returnOf || "",               // AE (index 30)
-    trip.previousId || ""              // AF (index 31)
+    trip.previousId || "",             // AF (index 31)
+    JSON.stringify(trip.standing || {}) // AG (index 32)
   ];
 }
 
@@ -166,7 +167,9 @@ function convertRawData(value) {
     driver: tripRow[20],        // U: DRIVER
     id: tripRow[23],            // X: UUID
     notes: tripRow[24],         // Y: Notes
-    returnOf: tripRow[30] || "" // AE: returnOf
+    returnOf: tripRow[30] || "", // AE: returnOf
+    previousId: tripRow[31] || "", // AF
+    standing: (() => { try { return JSON.parse(tripRow[32] || '{}'); } catch (e) { return {}; } })()
   }));
 }
 
@@ -187,7 +190,8 @@ function convertRowToTrip(row) {
     id: row[23],                       // X
     notes: row[24],                    // Y
     returnOf: row[30] || "",           // AE
-    previousId: row[31] || ""          // AF
+    previousId: row[31] || "",         // AF
+    standing: (() => { try { return JSON.parse(row[32] || '{}'); } catch (e) { return {}; } })()
   };
 }
 
@@ -208,6 +212,7 @@ function dispatchRowToTripObject(row) {
     notes: row[22],              // W: Notes
     returnOf: row[30] || "",     // AE: returnOf (optional)
     status: row[24] || "",       // Y: Status
+    standing: (() => { try { return JSON.parse(row[32] || '{}'); } catch (e) { return {}; } })()
   };
 }
 

--- a/TripFormFields.html
+++ b/TripFormFields.html
@@ -81,6 +81,41 @@
     <input type="time" id="return-trip-time" class="trip-input" />
   </div>
 
+  <div style="margin-top: 12px;">
+    <label>
+      <input type="checkbox" id="standing-order-checkbox" onchange="toggleStandingOrder()" />
+      Standing order
+    </label>
+  </div>
+
+  <div id="standing-order-container" style="display:none;margin-top:8px;">
+    <label>Frequency</label>
+    <select id="standing-frequency" class="trip-input" onchange="toggleCustomDays()">
+      <option value="DAILY">Daily</option>
+      <option value="WEEKDAYS">Weekdays (Mon–Fri)</option>
+      <option value="WEEKENDS">Weekends</option>
+      <option value="WEEKLY">Weekly</option>
+      <option value="BIWEEKLY">Bi-weekly</option>
+      <option value="MONTHLY">Monthly</option>
+    </select>
+
+    <div id="custom-days" style="display:none;margin-top:8px;">
+      <label><input type="checkbox" value="MON">Mon</label>
+      <label><input type="checkbox" value="TUE">Tue</label>
+      <label><input type="checkbox" value="WED">Wed</label>
+      <label><input type="checkbox" value="THU">Thu</label>
+      <label><input type="checkbox" value="FRI">Fri</label>
+      <label><input type="checkbox" value="SAT">Sat</label>
+      <label><input type="checkbox" value="SUN">Sun</label>
+    </div>
+
+    <label>Start Date</label>
+    <input type="date" id="standing-start-date" class="trip-input" />
+
+    <label>End Date</label>
+    <input type="date" id="standing-end-date" class="trip-input" />
+  </div>
+
 
   <label>Vehicle</label>
   <input list="vehicle-options" id="trip-vehicle" class="trip-input" placeholder="Enter or select vehicle">

--- a/TripManager.js
+++ b/TripManager.js
@@ -108,6 +108,9 @@ class TripManager {
       }
     }
     const newRow = this.logManager.tripToRow(trip);
+    if (trip.standing) {
+      newRow[32] = JSON.stringify(trip.standing);
+    }
     trips = trips.filter(t => t[23] !== trip.id);
     trips.push(newRow);
     const sorted = sortTripsByTime(trips);


### PR DESCRIPTION
## Summary
- store standing-order info as JSON when writing trips to the log
- include standing-order metadata when logging trips

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c7900de0c832fb6d9996b2a7d7cc8