### PR TITLE
Fix standing order deletion logic

### DIFF
--- a/TripManager.js
+++ b/TripManager.js
@@ -316,9 +316,10 @@ class TripManager {
     const allTrips = this.getAllTrips();
     const target = JSON.stringify(standing);
     allTrips.forEach(trip => {
-      const st = JSON.stringify(trip.standing || {});
+      const obj = Array.isArray(trip) ? this.logManager.rowToTrip(trip) : trip;
+      const st = JSON.stringify(obj.standing || {});
       if (st === target) {
-        this.deleteTripFromLog(trip.id, trip.date);
+        this.deleteTripFromLog(obj.id, obj.date);
       }
     });
   }


### PR DESCRIPTION
## Summary
- convert rows to trip objects before comparing standing orders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ccb03e4b8832fa32fdebe63bac7ce