### PR TITLE
Fix date formatting in convertRawData

### DIFF
--- a/Helpers.js
+++ b/Helpers.js
@@ -151,7 +151,7 @@ function tripObjectToRowArray(trip) {
 function convertRawData(value) {
   const rawTrips = JSON.parse(value || "[]");
   return rawTrips.map(tripRow => ({
-    date: tripRow[0],           // A: Date
+    date: formatDateString(tripRow[0]),           // A: Date
     startTime: tripRow[1],      // B: Start Time
     time: tripRow[2],           // C: Time
     passenger: tripRow[3],      // D: Passenger


### PR DESCRIPTION
## Summary
- normalize trip dates in `convertRawData` to use `formatDateString`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d26bbf8f4832f92be6d169eed444b