### PR TITLE
Add standing order date validation

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -213,6 +213,18 @@
             days: Array.from(document.querySelectorAll("#custom-days input:checked"))
               .map(cb => cb.value)
           };
+          const start = parseLocalDate(trip.standing.startDate);
+          const end = parseLocalDate(trip.standing.endDate);
+          if (end < start) {
+            alert("🚫 Standing order end date cannot be before start date.");
+            overlay.style.display = "none";
+            return;
+          }
+          if ((end - start) / 86400000 > 183) {
+            alert("🚫 Standing order cannot exceed 183 days.");
+            overlay.style.display = "none";
+            return;
+          }
         }
 
         const isReturnTrip = document.getElementById("return-trip-checkbox")?.checked;

--- a/TripFormFields.html
+++ b/TripFormFields.html
@@ -152,6 +152,26 @@
   const pickupInput = document.getElementById("trip-pickup");
   const dropoffInput = document.getElementById("trip-dropoff");
   const mapsLink = document.getElementById("maps-directions-link");
+  const standingStartInput = document.getElementById("standing-start-date");
+  const standingEndInput = document.getElementById("standing-end-date");
+
+  function updateStandingEndMax() {
+    if (!standingStartInput || !standingEndInput) return;
+    standingEndInput.min = standingStartInput.value;
+    if (typeof parseLocalDate === "function") {
+      const start = parseLocalDate(standingStartInput.value);
+      if (!isNaN(start)) {
+        const max = new Date(start.getTime() + 183 * 86400000);
+        standingEndInput.max = max.toISOString().slice(0, 10);
+        if (
+          standingEndInput.value &&
+          standingEndInput.value < standingStartInput.value
+        ) {
+          standingEndInput.value = standingStartInput.value;
+        }
+      }
+    }
+  }
 
   function updateMapsLink() {
     const pu = pickupInput.value.trim();
@@ -168,5 +188,9 @@
 
   pickupInput.addEventListener("input", updateMapsLink);
   dropoffInput.addEventListener("input", updateMapsLink);
+  if (standingStartInput) {
+    document.addEventListener("DOMContentLoaded", updateStandingEndMax);
+    standingStartInput.addEventListener("change", updateStandingEndMax);
+  }
   //]]>
 </script>


### PR DESCRIPTION
## Summary
- add validation for standing order start and end dates
- adjust `standing-end-date` selection range when start date changes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d29033104832f91adcbd5cf196398