### PR TITLE
Add modal to delete standing order dates

### DIFF
--- a/EditTripPage.html
+++ b/EditTripPage.html
@@ -20,6 +20,17 @@
 
     </div>
 
+    <div id="delete-modal" class="modal hidden">
+      <div class="modal-content">
+        <div class="modal-message">Select dates to delete</div>
+        <div id="standing-dates" style="max-height:150px;overflow-y:auto;text-align:left;margin-bottom:8px;"></div>
+        <div class="modal-actions">
+          <button class="btn-cancel" onclick="closeDeleteModal()">Cancel</button>
+          <button class="btn-full" onclick="confirmDeleteSelected()">Delete selected dates</button>
+        </div>
+      </div>
+    </div>
+
     <?!= include('SharedLoaders') ?>
 
     <script>
@@ -82,6 +93,54 @@
         const hours = String(date.getHours()).padStart(2, '0');
         const minutes = String(date.getMinutes()).padStart(2, '0');
         return `${hours}:${minutes}`;
+      }
+
+      function parseLocalDate(dateStr) {
+        if (!dateStr) return new Date(NaN);
+        const [y, m, d] = dateStr.split("-").map(Number);
+        return new Date(y, m - 1, d);
+      }
+
+      function expandStandingOrder(trip) {
+        if (!trip || !trip.standing) return [];
+        const { startDate, endDate, frequency, days = [] } = trip.standing;
+        if (!startDate || !endDate) return [];
+        const start = parseLocalDate(startDate);
+        const end = parseLocalDate(endDate);
+        const dayNames = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+        const results = [];
+        for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+          const dayName = dayNames[d.getDay()];
+          const diffDays = Math.floor((d - start) / 86400000);
+          let include = false;
+          switch (frequency) {
+            case "DAILY":
+              include = true;
+              break;
+            case "WEEKDAYS":
+              include = d.getDay() >= 1 && d.getDay() <= 5;
+              break;
+            case "WEEKENDS":
+              include = d.getDay() === 0 || d.getDay() === 6;
+              break;
+            case "WEEKLY":
+              include = days.length ? days.includes(dayName) : dayName === dayNames[start.getDay()];
+              break;
+            case "BIWEEKLY":
+              include = (days.length ? days.includes(dayName) : dayName === dayNames[start.getDay()]) && Math.floor(diffDays / 7) % 2 === 0;
+              break;
+            case "MONTHLY":
+              include = d.getDate() === start.getDate();
+              if (days.length) include = include && days.includes(dayName);
+              break;
+            default:
+              include = true;
+          }
+          if (include) {
+            results.push(d.toISOString().slice(0, 10));
+          }
+        }
+        return results;
       }
 
       function goBack() {
@@ -151,37 +210,23 @@
       }
 
       function confirmDelete() {
-        document.getElementById("loading-overlay").style.display = "flex";
-
         const id = document.getElementById("trip-id").value;
         const date = document.getElementById("trip-date").value;
 
-        if (!id) {
-          document.getElementById("loading-overlay").style.display = "none";
-          return;
-        }
-
+        if (!id) return;
         if (!date) {
-          document.getElementById("loading-overlay").style.display = "none";
           alert("Date must be provided");
           return;
         }
 
-        let deleteAll = false;
         if (currentTrip && currentTrip.standing && Object.keys(currentTrip.standing).length) {
-          deleteAll = confirm("This trip is part of a standing order.\nPress OK to delete the entire standing order, or Cancel to delete only this trip.");
-          const msg = deleteAll ? "Are you sure you want to delete the entire standing order?" : "Are you sure you want to delete this trip?";
-          if (!confirm(msg)) {
-            document.getElementById("loading-overlay").style.display = "none";
-            return;
-          }
-        } else {
-          if (!confirm("Are you sure you want to delete this trip?")) {
-            document.getElementById("loading-overlay").style.display = "none";
-            return;
-          }
+          openDeleteModal();
+          return;
         }
 
+        if (!confirm("Are you sure you want to delete this trip?")) return;
+
+        document.getElementById("loading-overlay").style.display = "flex";
         const runner = google.script.run
           .withSuccessHandler(() => {
             const d = document.getElementById("trip-date").value;
@@ -198,11 +243,53 @@
           })
           .withFailureHandler(handleError);
 
-        if (deleteAll) {
-          runner.deleteStandingOrder(currentTrip.standing);
-        } else {
-          runner.deleteTripFromLog(id, date);
-        }
+        runner.deleteTripFromLog(id, date);
+      }
+
+      function openDeleteModal() {
+        const container = document.getElementById("standing-dates");
+        container.innerHTML = "";
+        const dates = expandStandingOrder(currentTrip);
+        dates.forEach(d => {
+          const label = document.createElement("label");
+          const cb = document.createElement("input");
+          cb.type = "checkbox";
+          cb.value = d;
+          cb.checked = true;
+          label.appendChild(cb);
+          label.append(" " + d);
+          container.appendChild(label);
+        });
+        document.getElementById("delete-modal").classList.remove("hidden");
+      }
+
+      function closeDeleteModal() {
+        document.getElementById("delete-modal").classList.add("hidden");
+      }
+
+      function confirmDeleteSelected() {
+        const selected = Array.from(document.querySelectorAll("#standing-dates input:checked"))
+          .map(cb => cb.value);
+        document.getElementById("delete-modal").classList.add("hidden");
+        if (selected.length === 0) return;
+        document.getElementById("loading-overlay").style.display = "flex";
+        const runner = google.script.run
+          .withSuccessHandler(() => {
+            const d = document.getElementById("trip-date").value;
+            google.script.run
+              .withSuccessHandler(() => {
+                document.getElementById("loading-overlay").style.display = "none";
+                google.script.run
+                  .withSuccessHandler()
+                  .withFailureHandler(handleError)
+                  .openPassengerTripList(d);
+              })
+              .withFailureHandler(handleError)
+              .snapshotDispatchToLog();
+          })
+          .withFailureHandler(handleError);
+
+        runner.deleteStandingOrderOnDates(currentTrip.standing, selected);
       }
     </script>
   </body>

--- a/TripManager.js
+++ b/TripManager.js
@@ -323,6 +323,21 @@ class TripManager {
       }
     });
   }
+
+  deleteStandingOrderOnDates(standing, dates) {
+    if (!standing || !Array.isArray(dates) || dates.length === 0) return;
+    const target = JSON.stringify(standing);
+    const dateSet = new Set(dates.map(d => Utils.formatDateString(d)));
+    const allTrips = this.getAllTrips();
+    allTrips.forEach(trip => {
+      const obj = Array.isArray(trip) ? this.logManager.rowToTrip(trip) : trip;
+      const st = JSON.stringify(obj.standing || {});
+      const tripDate = Utils.formatDateString(obj.date || "");
+      if (st === target && dateSet.has(tripDate)) {
+        this.deleteTripFromLog(obj.id, obj.date);
+      }
+    });
+  }
 }
 
 const tripManager = new TripManager(spreadsheetService, logManager);
@@ -334,3 +349,4 @@ function getAllTrips() { return tripManager.getAllTrips(); }
 function updateTripInLog(trip) { return tripManager.updateTripInLog(trip); }
 function deleteTripFromLog(id, date) { return tripManager.deleteTripFromLog(id, date); }
 function deleteStandingOrder(standing) { return tripManager.deleteStandingOrder(standing); }
+function deleteStandingOrderOnDates(standing, dates) { return tripManager.deleteStandingOrderOnDates(standing, dates); }

--- a/TripStyles.html
+++ b/TripStyles.html
@@ -131,4 +131,89 @@
   .autocomplete-list li:hover {
     background-color: #f0f0f0;
   }
+
+  /* Shared modal styles copied from TripsPage.html */
+  .modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+  }
+
+  .modal.hidden {
+    display: none;
+  }
+
+  .modal-content {
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    width: 240px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    font-size: 13px;
+    text-align: center;
+  }
+
+  .modal-message {
+    margin-bottom: 16px;
+    font-weight: 500;
+  }
+
+  .modal-actions {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .modal-actions button {
+    flex: 1;
+    padding: 6px 10px;
+    margin: 0 4px;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    background: #007aff;
+    color: white;
+  }
+
+  .modal-actions button:last-child {
+    background: #ccc;
+    color: black;
+  }
+
+  .modal-actions.three-btns {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .modal-actions.three-btns button {
+    flex: 1;
+    padding: 6px 10px;
+    font-size: 12px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+
+  .modal-actions .btn-cancel {
+    background: #ddd;
+    color: #333;
+  }
+
+  .modal-actions .btn-partial {
+    background: #f0f0f0;
+    color: #333;
+  }
+
+  .modal-actions .btn-full {
+    background: #007aff;
+    color: white;
+  }
 </style>


### PR DESCRIPTION
## Summary
- share modal CSS across pages
- add modal to choose standing order dates in EditTripPage
- compute standing order dates client-side and open modal when deleting
- allow deleting standing orders on selected dates server-side

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d2f2b3bec832fb830b6f1bc8fad5e