### PR TITLE
Hide standing order controls on edit page

### DIFF
--- a/EditTripPage.html
+++ b/EditTripPage.html
@@ -28,6 +28,20 @@
       let currentTrip = null;
 
       document.addEventListener("DOMContentLoaded", () => {
+        // Hide add-trip only checkboxes
+        const rtInput = document.getElementById("return-trip-checkbox");
+        if (rtInput && rtInput.parentElement && rtInput.parentElement.parentElement) {
+          rtInput.parentElement.parentElement.style.display = "none";
+        }
+        const rtContainer = document.getElementById("return-time-container");
+        if (rtContainer) rtContainer.style.display = "none";
+        const soInput = document.getElementById("standing-order-checkbox");
+        if (soInput && soInput.parentElement && soInput.parentElement.parentElement) {
+          soInput.parentElement.parentElement.style.display = "none";
+        }
+        const soContainer = document.getElementById("standing-order-container");
+        if (soContainer) soContainer.style.display = "none";
+
         const parsedTrip = { id: rawTripId, date: rawTripDate };
         const safeId = encodeURIComponent(parsedTrip.id);
         const safeDate = rawTripDate ? formatDateString(new Date(rawTripDate)) : "";


### PR DESCRIPTION
## Summary
- hide standing order and return trip options when editing a trip

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d3040c350832fa78fa53b9208bf9e