### PR TITLE
Move modal styles to shared file

### DIFF
--- a/TripsPage.html
+++ b/TripsPage.html
@@ -4,6 +4,7 @@
   <base target="_top" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+  <?!= include('TripStyles') ?>
   <style>
     * {
       box-sizing: border-box;
@@ -199,89 +200,6 @@
       to { transform: rotate(360deg); }
     }
 
-    .modal {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(0,0,0,0.5);
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      z-index: 9999;
-    }
-
-    .modal.hidden {
-      display: none;
-    }
-
-    .modal-content {
-      background: white;
-      padding: 20px;
-      border-radius: 8px;
-      width: 240px;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-      font-size: 13px;
-      text-align: center;
-    }
-
-    .modal-message {
-      margin-bottom: 16px;
-      font-weight: 500;
-    }
-
-    .modal-actions {
-      display: flex;
-      justify-content: space-between;
-    }
-
-    .modal-actions button {
-      flex: 1;
-      padding: 6px 10px;
-      margin: 0 4px;
-      border: none;
-      border-radius: 4px;
-      font-size: 12px;
-      cursor: pointer;
-      background: #007aff;
-      color: white;
-    }
-
-    .modal-actions button:last-child {
-      background: #ccc;
-      color: black;
-    }
-
-    .modal-actions.three-btns {
-      display: flex;
-      justify-content: space-between;
-      gap: 8px;
-    }
-
-    .modal-actions.three-btns button {
-      flex: 1;
-      padding: 6px 10px;
-      font-size: 12px;
-      border: none;
-      border-radius: 6px;
-      cursor: pointer;
-    }
-
-    .modal-actions .btn-cancel {
-      background: #ddd;
-      color: #333;
-    }
-
-    .modal-actions .btn-partial {
-      background: #f0f0f0;
-      color: #333;
-    }
-
-    .modal-actions .btn-full {
-      background: #007aff;
-      color: white;
-    }
 
     .date-label {
       font-size: 10px;


### PR DESCRIPTION
## Summary
- share modal styles across pages via TripStyles include
- remove duplicated modal CSS from TripsPage
- add TripStyles include to TripsPage

## Testing
- `grep -n modal TripsPage.html | head`

------
https://chatgpt.com/codex/tasks/task_e_685d32d98e34832fa3f97a16d0013b01