### PR TITLE
Organize trip tests

### DIFF
--- a/TripsTest.js
+++ b/TripsTest.js
@@ -1,0 +1,82 @@
+class TripsTest {
+  deleteStandingOrderOnDates() {
+    const ss = SpreadsheetApp.create('DeleteStandingOrderTest');
+    const logSheet = ss.getSheets()[0];
+    logSheet.setName('LOG');
+    logSheet.getRange('A1:B1').setValues([['Date', 'Trips']]);
+
+    const service = new SpreadsheetService({ Dispatcher: ss.getId() });
+    const manager = new TripManager(service, logManager);
+
+    const standing = { key: 'STANDING1' };
+
+    const baseTrip = {
+      startTime: '',
+      time: '09:00',
+      passenger: '',
+      transport: '',
+      phone: '',
+      medicaid: '',
+      invoice: '',
+      pickup: '',
+      dropoff: '',
+      status: '',
+      vehicle: '',
+      driver: '',
+      notes: '',
+      returnOf: '',
+      previousId: '',
+      standing
+    };
+    const trip1 = Object.assign({ id: 't1', date: '2024-06-01' }, baseTrip);
+    const trip2 = Object.assign({ id: 't2', date: '2024-06-02' }, baseTrip);
+
+    manager.addTripToLog(trip1);
+    manager.addTripToLog(trip2);
+
+    manager.deleteStandingOrderOnDates(standing, ['2024-06-01']);
+
+    const remaining = manager.getAllTrips().map(t => t.id);
+    if (remaining.length !== 1 || remaining[0] !== 't2') {
+      throw new Error('Trip was not removed from log sheet');
+    } else {
+      Logger.log('testDeleteStandingOrderOnDates passed');
+    }
+
+    DriveApp.getFileById(ss.getId()).setTrashed(true);
+  }
+
+  testOnEdit() {
+    tripManager.testOnEdit();
+  }
+
+  showAddTripSidebar(date) {
+    tripRouter.showAddTripSidebar(date);
+  }
+
+  openEditTripSidebar(id) {
+    tripRouter.openEditTripSidebar(id);
+  }
+
+  showEditTripSidebar(id, date) {
+    tripRouter.showEditTripSidebar(id, date);
+  }
+
+  openPassengerTripList(date) {
+    tripRouter.openPassengerTripList(date);
+  }
+
+  showRestoreDatePicker() {
+    tripRouter.showRestoreDatePicker();
+  }
+}
+
+const tripsTest = new TripsTest();
+
+function TEST_deleteStandingOrderOnDates() { tripsTest.deleteStandingOrderOnDates(); }
+function TEST_onEdit() { tripsTest.testOnEdit(); }
+function TEST_showAddTripSidebar(date) { tripsTest.showAddTripSidebar(date); }
+function TEST_openEditTripSidebar(id) { tripsTest.openEditTripSidebar(id); }
+function TEST_showEditTripSidebar(id, date) { tripsTest.showEditTripSidebar(id, date); }
+function TEST_openPassengerTripList(date) { tripsTest.openPassengerTripList(date); }
+function TEST_showRestoreDatePicker() { tripsTest.showRestoreDatePicker(); }


### PR DESCRIPTION
## Summary
- replace old `Tests.js` with new `TripsTest` class
- expose helpers to call sidebar and log tests during debugging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d41a4e1cc832fb3eb240df3e93b5c