### PR TITLE
Fix date parsing

### DIFF
--- a/Helpers.js
+++ b/Helpers.js
@@ -94,8 +94,11 @@ function toTimeOnlySmart(val) {
 }
 
 function formatDateString(date) {
-  if (typeof date === 'string') return date;
-  return Utilities.formatDate(new Date(date), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+  const parsed = new Date(date);
+  if (isNaN(parsed)) {
+    return typeof date === 'string' ? date : '';
+  }
+  return Utilities.formatDate(parsed, Session.getScriptTimeZone(), 'yyyy-MM-dd');
 }
 
 function uiCellFormat(date){

--- a/TripManager.js
+++ b/TripManager.js
@@ -326,13 +326,14 @@ class TripManager {
 
   deleteStandingOrderOnDates(standing, dates) {
     if (!standing || !Array.isArray(dates)) return;
+    const normalizedDates = dates.map(d => Utils.formatDateString(d));
     const allTrips = this.getAllTrips();
     const target = JSON.stringify(standing);
     allTrips.forEach(trip => {
       const obj = Array.isArray(trip) ? this.logManager.rowToTrip(trip) : trip;
       if (
         JSON.stringify(obj.standing || {}) === target &&
-        dates.includes(Utils.formatDateString(obj.date))
+        normalizedDates.includes(Utils.formatDateString(obj.date))
       ) {
         this.deleteTripFromLog(obj.id, obj.date);
       }

--- a/Utils.js
+++ b/Utils.js
@@ -1,7 +1,10 @@
 class Utils {
   static formatDateString(date) {
-    if (typeof date === 'string') return date;
-    return Utilities.formatDate(new Date(date), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    const parsed = new Date(date);
+    if (isNaN(parsed)) {
+      return typeof date === 'string' ? date : '';
+    }
+    return Utilities.formatDate(parsed, Session.getScriptTimeZone(), 'yyyy-MM-dd');
   }
 }
 


### PR DESCRIPTION
## Summary
- parse all inputs in `Utils.formatDateString` and `formatDateString` in `Helpers.js`
- normalize dates before comparing in `TripManager.deleteStandingOrderOnDates`

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685d5ade04c4832f8b106bf392518aed