### PR TITLE
Fix date utils and refactor helpers

### DIFF
--- a/Helpers.js
+++ b/Helpers.js
@@ -93,13 +93,6 @@ function toTimeOnlySmart(val) {
   return new Date(1899, 11, 30, d.getHours(), d.getMinutes());
 }
 
-function formatDateString(date) {
-  const parsed = new Date(date);
-  if (isNaN(parsed)) {
-    return typeof date === 'string' ? date : '';
-  }
-  return Utilities.formatDate(parsed, Session.getScriptTimeZone(), 'yyyy-MM-dd');
-}
 
 function uiCellFormat(date){
   const d = new Date(date);
@@ -154,7 +147,7 @@ function tripObjectToRowArray(trip) {
 function convertRawData(value) {
   const rawTrips = JSON.parse(value || "[]");
   return rawTrips.map(tripRow => ({
-    date: formatDateString(tripRow[0]),           // A: Date
+    date: Utils.formatDateString(tripRow[0]),           // A: Date
     startTime: tripRow[1],      // B: Start Time
     time: tripRow[2],           // C: Time
     passenger: tripRow[3],      // D: Passenger
@@ -178,7 +171,7 @@ function convertRawData(value) {
 
 function convertRowToTrip(row) {
   return {
-    date: formatDateString(row[0]),    // A
+    date: Utils.formatDateString(row[0]),    // A
     time: row[2],                      // C
     passenger: row[3],                 // D
     transport: row[5],                 // F

--- a/Utils.js
+++ b/Utils.js
@@ -1,10 +1,14 @@
 class Utils {
   static formatDateString(date) {
-    const parsed = new Date(date);
-    if (isNaN(parsed)) {
-      return typeof date === 'string' ? date : '';
+    if (!date) return '';
+    if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      const [y, m, d] = date.split('-').map(Number);
+      return Utilities.formatDate(new Date(y, m - 1, d), Session.getScriptTimeZone(), 'yyyy-MM-dd');
     }
-    return Utilities.formatDate(parsed, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    const parsed = new Date(date);
+    return isNaN(parsed)
+      ? (typeof date === 'string' ? date : '')
+      : Utilities.formatDate(parsed, Session.getScriptTimeZone(), 'yyyy-MM-dd');
   }
 }
 


### PR DESCRIPTION
## Summary
- implement improved timezone-safe parser in `Utils.formatDateString`
- remove duplicated `formatDateString` from `Helpers.js`
- update helper functions to use `Utils.formatDateString`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_685d6408547c832f827457ac6d68f6e1