### PR TITLE
Add debug log to deleteStandingOrderOnDates

### DIFF
--- a/TripManager.js
+++ b/TripManager.js
@@ -331,6 +331,14 @@ class TripManager {
     const target = JSON.stringify(standing);
     allTrips.forEach(trip => {
       const obj = Array.isArray(trip) ? this.logManager.rowToTrip(trip) : trip;
+      console.log(
+        obj,
+        JSON.stringify(obj.standing || {}),
+        target,
+        Utils.formatDateString(obj.date),
+        JSON.stringify(obj.standing || {}) === target &&
+          normalizedDates.includes(Utils.formatDateString(obj.date))
+      );
       if (
         JSON.stringify(obj.standing || {}) === target &&
         normalizedDates.includes(Utils.formatDateString(obj.date))


### PR DESCRIPTION
## Summary
- add console.log inside `deleteStandingOrderOnDates` to display debugging info about each trip

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d6a799a74832f9a44f74724641e26