### PR TITLE
Fix undefined variable in fromTimeOnly

### DIFF
--- a/Helpers.js
+++ b/Helpers.js
@@ -69,6 +69,7 @@ function fromTimeOnly(val) {
     return val;
   }
 
+  const d = new Date(val);
   const t = new Date(1899, 11, 30, d.getHours(), d.getMinutes()); // ✅ local time
   return t.toISOString(); // if string is truly needed
 }


### PR DESCRIPTION
## Summary
- define `d` inside `fromTimeOnly` so its hours and minutes can be used

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d8275e2f4832f924fd8f0e9dc25df