### PR TITLE
Fix date lookup timezone bug

### DIFF
--- a/SideBarSnapShots.js
+++ b/SideBarSnapShots.js
@@ -87,7 +87,7 @@ function snapshotDispatchToLog(isAlert = false) {
     const dateVal = row[0];
     const key = dateVal === '' || dateVal == null
       ? ''
-      : Utilities.formatDate(new Date(dateVal), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+      : Utils.formatDateString(dateVal);
 
     if (key === '' && blankRow === null) blankRow = i + 2;
 
@@ -182,7 +182,7 @@ function restoreDispatchFromLog(date) {
   const rowIndex = logData.findIndex(row => {
     const rowDate = row[0];
     if (!rowDate) return false;
-    const formatted = Utilities.formatDate(new Date(rowDate), Session.getScriptTimeZone(), "yyyy-MM-dd");
+    const formatted = Utils.formatDateString(rowDate);
     return formatted === targetDate;
   });
 

--- a/TripManager.js
+++ b/TripManager.js
@@ -96,7 +96,7 @@ class TripManager {
       rowIndex = allData.findIndex(row => {
         const rowDate = row[0];
         if (!rowDate) return false;
-        const formatted = Utilities.formatDate(new Date(rowDate), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+        const formatted = Utils.formatDateString(rowDate);
         return formatted === normalizedDate;
       });
       if (rowIndex !== -1) {
@@ -203,7 +203,7 @@ class TripManager {
         if (trips.some(t => t[23] === trip.id)) {
           sourceRowIndex = i;
           sourceTrips = trips;
-          sourceDateKey = rowDate ? Utilities.formatDate(new Date(rowDate), Session.getScriptTimeZone(), 'yyyy-MM-dd') : '';
+          sourceDateKey = rowDate ? Utils.formatDateString(rowDate) : '';
           break;
         }
       } catch (e) {
@@ -225,7 +225,7 @@ class TripManager {
       let targetRowIndex = allData.findIndex(row => {
         const rowDate = row[0];
         if (!rowDate) return false;
-        const formatted = Utilities.formatDate(new Date(rowDate), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+        const formatted = Utils.formatDateString(rowDate);
         return formatted === normalizedDate;
       });
       if (targetRowIndex !== -1) {
@@ -275,7 +275,7 @@ class TripManager {
     let trips = [];
     for (let i = 0; i < allData.length; i++) {
       const rowDate = allData[i][0];
-      const formattedDate = rowDate ? Utilities.formatDate(new Date(rowDate), Session.getScriptTimeZone(), 'yyyy-MM-dd') : '';
+      const formattedDate = rowDate ? Utils.formatDateString(rowDate) : '';
       if (formattedDate === targetDate) {
         rowIndex = i;
         break;


### PR DESCRIPTION
## Summary
- use `Utils.formatDateString` when comparing dates read from sheets
- handle string dates correctly when restoring snapshots

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685f741ddb44832f88f10c951874323c