### PR TITLE
Fix date formatting

### DIFF
--- a/TripManager.js
+++ b/TripManager.js
@@ -347,6 +347,19 @@ class TripManager {
       }
     });
   }
+
+  rebuildDateIndex() {
+    const sheet = this.logSheet;
+    const last = sheet.getLastRow();
+    const dates = sheet.getRange(2, 1, Math.max(last - 1, 0), 1).getValues();
+    const index = {};
+    dates.forEach((row, i) => {
+      index[Utils.formatDateString(row[0])] = i;
+    });
+    this.dateIndex = index;
+    saveDateIndex(this.dateIndex);
+    for (const k in logIndexCache) delete logIndexCache[k];
+  }
 }
 
 const tripManager = new TripManager(spreadsheetService, logManager);
@@ -359,3 +372,4 @@ function updateTripInLog(trip) { return tripManager.updateTripInLog(trip); }
 function deleteTripFromLog(id, date) { return tripManager.deleteTripFromLog(id, date); }
 function deleteStandingOrder(standing) { return tripManager.deleteStandingOrder(standing); }
 function deleteStandingOrderOnDates(standing, dates) { return tripManager.deleteStandingOrderOnDates(standing, dates); }
+function rebuildLogDateIndex() { return tripManager.rebuildDateIndex(); }

--- a/Utils.js
+++ b/Utils.js
@@ -1,14 +1,21 @@
 class Utils {
   static formatDateString(date) {
     if (!date) return '';
-    if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+
+    // Return already normalized strings unchanged
+    if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date.trim())) {
       const [y, m, d] = date.split('-').map(Number);
-      return Utilities.formatDate(new Date(y, m - 1, d), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+      const utcDate = new Date(Date.UTC(y, m - 1, d));
+      return Utilities.formatDate(utcDate, 'UTC', 'yyyy-MM-dd');
     }
+
     const parsed = new Date(date);
-    return isNaN(parsed)
-      ? (typeof date === 'string' ? date : '')
-      : Utilities.formatDate(parsed, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    if (isNaN(parsed)) {
+      return typeof date === 'string' ? date : '';
+    }
+
+    const neutral = new Date(parsed.getTime() - parsed.getTimezoneOffset() * 60000);
+    return Utilities.formatDate(neutral, 'UTC', 'yyyy-MM-dd');
   }
 }
 


### PR DESCRIPTION
## Summary
- make `Utils.formatDateString` timezone neutral using UTC
- allow rebuilding log date index

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68601b3857a0832f933c471ec7d6d695