### PR TITLE
Centralize date/time helpers

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -19,6 +19,7 @@
     </div>
 
     <?!= include('SharedLoaders') ?>
+    <?!= include('Utils') ?>
 
     <script>
       const initialDate = <?= JSON.stringify(initialDate) ?>;
@@ -100,12 +101,6 @@
         }
       }
 
-      function parseLocalDate(dateStr) {
-        if (!dateStr) return new Date(NaN);
-        const [y, m, d] = dateStr.split("-").map(Number);
-        return new Date(y, m - 1, d);
-      }
-
 
       function submitNewTrip() {
         document.getElementById("loading-overlay").style.display = "flex";
@@ -157,8 +152,8 @@
             days: Array.from(document.querySelectorAll("#custom-days input:checked"))
               .map(cb => cb.value)
           };
-          const start = parseLocalDate(trip.standing.startDate);
-          const end = parseLocalDate(trip.standing.endDate);
+          const start = Utils.parseLocalDate(trip.standing.startDate);
+          const end = Utils.parseLocalDate(trip.standing.endDate);
           if (end < start) {
             alert("🚫 Standing order end date cannot be before start date.");
             overlay.style.display = "none";

--- a/EditTripPage.html
+++ b/EditTripPage.html
@@ -32,6 +32,7 @@
     </div>
 
     <?!= include('SharedLoaders') ?>
+    <?!= include('Utils') ?>
 
     <script>
       const rawTripId = <?= JSON.stringify(tripId) ?>.replace(/^"+|"+$/g, '');
@@ -55,7 +56,7 @@
 
         const parsedTrip = { id: rawTripId, date: rawTripDate };
         const safeId = encodeURIComponent(parsedTrip.id);
-        const safeDate = rawTripDate ? formatDateString(new Date(rawTripDate)) : "";
+        const safeDate = rawTripDate ? Utils.formatDateString(new Date(rawTripDate)) : "";
 
         document.getElementById("loading-overlay").style.display = "flex";
         google.script.run
@@ -90,30 +91,10 @@
       }
 
 
-      function formatDateString(date) {
-        return new Date(date).toISOString().slice(0, 10);
-      }
-
       function stripQuotes(str) {
         return typeof str === 'string' ? str.replace(/^"+|"+$/g, '').trim() : str;
       }
 
-      function formatTime(dateStr) {
-        return new Date(dateStr).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-      }
-
-      function convertISOStringToTimeInput(isoString) {
-        const date = new Date(isoString);
-        const hours = String(date.getHours()).padStart(2, '0');
-        const minutes = String(date.getMinutes()).padStart(2, '0');
-        return `${hours}:${minutes}`;
-      }
-
-      function parseLocalDate(dateStr) {
-        if (!dateStr) return new Date(NaN);
-        const [y, m, d] = dateStr.split("-").map(Number);
-        return new Date(y, m - 1, d);
-      }
 
       function goBack() {
         const date = document.getElementById("trip-date").value
@@ -127,8 +108,8 @@
 
       function populateTripForm(trip) {
         currentTrip = trip;
-        const time = convertISOStringToTimeInput(trip.time);
-        const tripDate = trip.date ? (formatDateString(trip.date) || '') : '';
+        const time = Utils.timeToString(trip.time);
+        const tripDate = trip.date ? (Utils.formatDateString(trip.date) || '') : '';
         
         toggleSaveButtonVisibility(tripDate);
         document.getElementById("loading-overlay").style.display = "none";

--- a/Helpers.js
+++ b/Helpers.js
@@ -62,17 +62,6 @@ function fromDateOnly(val) {
   return d // return Utilities.formatDate(d, Session.getScriptTimeZone(), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 }
 
-function fromTimeOnly(val) {
-  if (!val || isNaN(new Date(val))) return "";
-
-  if (typeof val === "string" && /^\d{4}-\d{2}-\d{2}T/.test(val)) {
-    return val;
-  }
-
-  const d = new Date(val);
-  const t = new Date(1899, 11, 30, d.getHours(), d.getMinutes()); // ✅ local time
-  return t.toISOString(); // if string is truly needed
-}
 
 function uiCellFormat(date){
   const d = new Date(date);

--- a/SharedLoaders.html
+++ b/SharedLoaders.html
@@ -144,11 +144,6 @@
     });
   }
 
-  function parseLocalDate(dateStr) {
-    if (!dateStr) return new Date(NaN);
-    const [y, m, d] = dateStr.split("-").map(Number);
-    return new Date(y, m - 1, d);
-  }
 
   function expandStandingOrder(trip) {
     if (!trip || !trip.standing) return trip && trip.date ? [trip.date] : [];
@@ -156,8 +151,8 @@
     const { startDate, endDate, frequency, days = [] } = trip.standing;
     if (!startDate || !endDate) return trip.date ? [trip.date] : [];
 
-    const start = parseLocalDate(startDate);
-    const end = parseLocalDate(endDate);
+    const start = Utils.parseLocalDate(startDate);
+    const end = Utils.parseLocalDate(endDate);
     const dayNames = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
     const results = [];
 

--- a/TripFormFields.html
+++ b/TripFormFields.html
@@ -158,8 +158,8 @@
   function updateStandingEndMax() {
     if (!standingStartInput || !standingEndInput) return;
     standingEndInput.min = standingStartInput.value;
-    if (typeof parseLocalDate === "function") {
-      const start = parseLocalDate(standingStartInput.value);
+    if (typeof Utils !== 'undefined') {
+      const start = Utils.parseLocalDate(standingStartInput.value);
       if (!isNaN(start)) {
         const max = new Date(start.getTime() + 183 * 86400000);
         standingEndInput.max = max.toISOString().slice(0, 10);

--- a/Utils.js
+++ b/Utils.js
@@ -17,6 +17,45 @@ class Utils {
     const neutral = new Date(parsed.getTime() - parsed.getTimezoneOffset() * 60000);
     return Utilities.formatDate(neutral, 'UTC', 'yyyy-MM-dd');
   }
+
+  static parseLocalDate(str) {
+    if (!str) return new Date(NaN);
+    if (str instanceof Date) {
+      return new Date(str.getFullYear(), str.getMonth(), str.getDate());
+    }
+    const parts = String(str).split('-');
+    if (parts.length === 3) {
+      const [y, m, d] = parts.map(Number);
+      if (![y, m, d].some(isNaN)) {
+        return new Date(y, m - 1, d);
+      }
+    }
+    const d = new Date(str);
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  }
+
+  static toTimeOnly(val) {
+    if (!val) return new Date(NaN);
+    const d = new Date(val);
+    if (isNaN(d)) return new Date(NaN);
+    return new Date(1899, 11, 30, d.getHours(), d.getMinutes(), d.getSeconds(), d.getMilliseconds());
+  }
+
+  static fromTimeOnly(val) {
+    if (!val) return '';
+    const d = new Date(val);
+    if (isNaN(d)) return '';
+    return Utils.toTimeOnly(d).toISOString();
+  }
+
+  static timeToString(val) {
+    const d = new Date(val);
+    if (isNaN(d)) return '';
+    const h = String(d.getHours()).padStart(2, '0');
+    const m = String(d.getMinutes()).padStart(2, '0');
+    return `${h}:${m}`;
+  }
 }
 
 const utils = Utils;
+


### PR DESCRIPTION
## Summary
- extend `Utils` with shared date & time helpers
- include `Utils` in AddTrip and EditTrip pages
- use `Utils.parseLocalDate` and `Utils.timeToString` in front-end scripts
- remove duplicate date parsing in shared loaders and trip form fields
- drop unused time conversion util from `Helpers.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68602484c06c832f8105286b612d25c9