### PR TITLE
Add standingOrder serialization

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -150,15 +150,15 @@
 
         const isStandingOrder = document.getElementById("standing-order-checkbox")?.checked;
         if (isStandingOrder) {
-          trip.standing = {
+          trip.standingOrder = {
             frequency: document.getElementById("standing-frequency").value,
             startDate: document.getElementById("standing-start-date").value,
             endDate: document.getElementById("standing-end-date").value,
             days: Array.from(document.querySelectorAll("#custom-days input:checked"))
               .map(cb => cb.value)
           };
-          const start = parseLocalDate(trip.standing.startDate);
-          const end = parseLocalDate(trip.standing.endDate);
+          const start = parseLocalDate(trip.standingOrder.startDate);
+          const end = parseLocalDate(trip.standingOrder.endDate);
           if (end < start) {
             alert("🚫 Standing order end date cannot be before start date.");
             overlay.style.display = "none";
@@ -182,6 +182,11 @@
         }
 
         const expandedDates = expandStandingOrder(trip);
+        if (isStandingOrder) {
+          trip.standingOrder.dates = expandedDates;
+          trip.standingOrder.withReturnTrip = isReturnTrip;
+        }
+
         const tripsToSave = [];
         expandedDates.forEach(dateStr => {
           const t = {
@@ -190,7 +195,7 @@
             id: `${driver}|${dateStr}|${time}|${passenger}|${pickup}`
           };
           if (isStandingOrder) {
-            t.standing = { ...trip.standing };
+            t.standingOrder = { ...trip.standingOrder };
           }
           tripsToSave.push(t);
 
@@ -205,7 +210,7 @@
               returnOf: t.id
             };
             if (isStandingOrder) {
-              rt.standing = { ...trip.standing };
+              rt.standingOrder = { ...trip.standingOrder };
             }
             tripsToSave.push(rt);
           }

--- a/EditTripPage.html
+++ b/EditTripPage.html
@@ -191,7 +191,7 @@
           return;
         }
 
-        if (currentTrip && currentTrip.standing && Object.keys(currentTrip.standing).length) {
+        if (currentTrip && currentTrip.standingOrder && Object.keys(currentTrip.standingOrder).length) {
           openDeleteModal();
           return;
         }
@@ -261,7 +261,7 @@
           })
           .withFailureHandler(handleError);
 
-        runner.deleteStandingOrderOnDates(currentTrip.standing, selected);
+        runner.deleteStandingOrderOnDates(currentTrip.standingOrder, selected);
       }
     </script>
   </body>

--- a/Helpers.js
+++ b/Helpers.js
@@ -176,13 +176,14 @@ function tripObjectToRowArray(trip) {
     trip.vehicle || "",                // R
     "", "",                            // S, T
     trip.driver || "",                 // U
-    "", "",                            // V, W
+    "",                                // V (index 21)
+    "",                                // W (index 22)
     trip.id || "",                     // X
     trip.notes || "",                  // Y
     "", "", "", "", "",                // Z - AD
     trip.returnOf || "",               // AE (index 30)
     trip.previousId || "",             // AF (index 31)
-    JSON.stringify(trip.standing || {}) // AG (index 32)
+    JSON.stringify(trip.standingOrder || {}) // AG (index 32)
   ];
 }
 
@@ -218,7 +219,7 @@ function convertRowToTrip(row) {
     notes: row[24],                    // Y
     returnOf: row[30] || "",           // AE
     previousId: row[31] || "",         // AF
-    standing: (() => { try { return JSON.parse(row[32] || '{}'); } catch (e) { return {}; } })()
+    standingOrder: (() => { try { return JSON.parse(row[32] || '{}'); } catch (e) { return {}; } })()
   };
 }
 
@@ -237,10 +238,11 @@ function dispatchRowToTripObject(row) {
     dropoff: row[11],            // L: Drop Off
     vehicle: row[12],            // M: Vehicle
     driver: row[14],             // O: DRIVER
+    standingOrder: (() => { try { return JSON.parse(row[32] || '{}'); } catch (e) { return {}; } })(),
     notes: row[22],              // W: Notes
     returnOf: row[30] || "",     // AE: returnOf (optional)
     status: row[24] || "",       // Y: Status
-    standing: (() => { try { return JSON.parse(row[32] || '{}'); } catch (e) { return {}; } })()
+
   };
 }
 

--- a/RecurringTrips.js
+++ b/RecurringTrips.js
@@ -23,7 +23,8 @@ class StandingOrderManager {
 
     const parentFields = parentTrip[1];
     const recurringId = parentFields[11];
-    const standingOrder = parentFields[21];
+    const standingOrder = parentFields[32];
+    parentFields[32] = standingOrder;
 
     const lastRow = logSheet.getLastRow();
     const data = lastRow > 1 ? logSheet.getRange(2, 1, lastRow - 1, 2).getValues() : [];
@@ -67,7 +68,7 @@ class StandingOrderManager {
       newFields[0] = dateStr;
       newFields[11] = newId;
       newFields[22] = recurringId;
-      newFields[21] = standingOrder;
+      newFields[32] = standingOrder;
       row.entries.push([newId, newFields]);
     });
 

--- a/SharedLoaders.html
+++ b/SharedLoaders.html
@@ -151,9 +151,9 @@
   }
 
   function expandStandingOrder(trip) {
-    if (!trip || !trip.standing) return trip && trip.date ? [trip.date] : [];
+    if (!trip || !trip.standingOrder) return trip && trip.date ? [trip.date] : [];
 
-    const { startDate, endDate, frequency, days = [] } = trip.standing;
+    const { startDate, endDate, frequency, days = [] } = trip.standingOrder;
     if (!startDate || !endDate) return trip.date ? [trip.date] : [];
 
     const start = parseLocalDate(startDate);

--- a/TripManager.js
+++ b/TripManager.js
@@ -265,36 +265,36 @@ class TripManager {
     range.setValue(JSON.stringify(sortTripMapByTime(trips)));
   }
 
-  deleteStandingOrder(standing) {
-    if (!standing) return;
+  deleteStandingOrder(standingOrder) {
+    if (!standingOrder) return;
     const allTrips = this.getAllTrips();
-    const target = JSON.stringify(standing);
+    const target = JSON.stringify(standingOrder);
     allTrips.forEach(trip => {
       const obj = Array.isArray(trip) ? this.logManager.rowToTrip(trip) : trip;
-      const st = JSON.stringify(obj.standing || {});
+      const st = JSON.stringify(obj.standingOrder || {});
       if (st === target) {
         this.deleteTripFromLog(obj.id, obj.date);
       }
     });
   }
 
-  deleteStandingOrderOnDates(standing, dates) {
-    if (!standing || !Array.isArray(dates)) return;
+  deleteStandingOrderOnDates(standingOrder, dates) {
+    if (!standingOrder || !Array.isArray(dates)) return;
     const normalizedDates = dates.map(d => Utils.formatDateString(d));
     const allTrips = this.getAllTrips();
-    const target = JSON.stringify(standing);
+    const target = JSON.stringify(standingOrder);
     allTrips.forEach(trip => {
       const obj = Array.isArray(trip) ? this.logManager.rowToTrip(trip) : trip;
       console.log(
         obj,
-        JSON.stringify(obj.standing || {}),
+        JSON.stringify(obj.standingOrder || {}),
         target,
         Utils.formatDateString(obj.date),
-        JSON.stringify(obj.standing || {}) === target &&
+        JSON.stringify(obj.standingOrder || {}) === target &&
           normalizedDates.includes(Utils.formatDateString(obj.date))
       );
       if (
-        JSON.stringify(obj.standing || {}) === target &&
+        JSON.stringify(obj.standingOrder || {}) === target &&
         normalizedDates.includes(Utils.formatDateString(obj.date))
       ) {
         this.deleteTripFromLog(obj.id, obj.date);
@@ -311,5 +311,5 @@ function getTripById(encodedId, date) { return tripManager.getTripById(encodedId
 function getAllTrips() { return tripManager.getAllTrips(); }
 function updateTripInLog(trip) { return tripManager.updateTripInLog(trip); }
 function deleteTripFromLog(id, date) { return tripManager.deleteTripFromLog(id, date); }
-function deleteStandingOrder(standing) { return tripManager.deleteStandingOrder(standing); }
-function deleteStandingOrderOnDates(standing, dates) { return tripManager.deleteStandingOrderOnDates(standing, dates); }
+function deleteStandingOrder(standingOrder) { return tripManager.deleteStandingOrder(standingOrder); }
+function deleteStandingOrderOnDates(standingOrder, dates) { return tripManager.deleteStandingOrderOnDates(standingOrder, dates); }

--- a/TripsTest.js
+++ b/TripsTest.js
@@ -8,7 +8,7 @@ class TripsTest {
     const service = new SpreadsheetService({ Dispatcher: ss.getId() });
     const manager = new TripManager(service, logManager);
 
-    const standing = {
+    const standingOrder = {
       frequency: 'DAILY',
       startDate: '2024-06-01',
       endDate: '2024-06-05',
@@ -31,7 +31,7 @@ class TripsTest {
       notes: 'This is a TEST !!!',
       returnOf: 'orig',
       previousId: '',
-      standing
+      standingOrder
     };
     const trip1 = Object.assign({ id: 't1', date: '2024-06-01' }, baseTrip);
     const trip2 = Object.assign({ id: 't2', date: '2024-06-02' }, baseTrip);
@@ -39,7 +39,7 @@ class TripsTest {
     manager.addTripToLog(trip1);
     manager.addTripToLog(trip2);
 
-    manager.deleteStandingOrderOnDates(standing, ['2024-06-01']);
+    manager.deleteStandingOrderOnDates(standingOrder, ['2024-06-01']);
 
     const remaining = manager.getAllTrips().map(t => t.id);
     if (remaining.length !== 1 || remaining[0] !== 't2') {


### PR DESCRIPTION
## Summary
- capture standing order details when adding trips
- store standingOrder data in LOG rows at column AG
- keep standingOrder info when cloning recurring trips
- rename deletion helpers to use standingOrder

## Testing
- `node -e "const fs=require('fs');let code=fs.readFileSync('Utils.js','utf8')+fs.readFileSync('Helpers.js','utf8');eval(code); const trip={date:'2024-06-20',startTime:'10:00',time:'10:00',passenger:'John',pickup:'A',standingOrder:{frequency:'DAILY',startDate:'2024-06-20',endDate:'2024-06-20'}}; const arr=tripObjectToRowArray(trip); console.log(arr[32]);"`
- ❌ `node -e "const fs=require('fs');let code=fs.readFileSync('Utils.js','utf8')+fs.readFileSync('Helpers.js','utf8');eval(code); const trip={date:'2024-06-20',startTime:'10:00',time:'10:00',passenger:'John',pickup:'A',standingOrder:{frequency:'DAILY',startDate:'2024-06-20',endDate:'2024-06-20'}}; const arr=tripObjectToRowArray(trip); const obj=convertRowToTrip(arr);"` (failed due to `Utilities` not defined)


------
https://chatgpt.com/codex/tasks/task_e_686209d64d10832fb6c795d64fc5ed82