### PR TITLE
Add recurringId tracking

### DIFF
--- a/EditTripPage.html
+++ b/EditTripPage.html
@@ -191,7 +191,7 @@
           return;
         }
 
-        if (currentTrip && currentTrip.standingOrder && Object.keys(currentTrip.standingOrder).length) {
+        if (currentTrip && currentTrip.recurringId) {
           openDeleteModal();
           return;
         }

--- a/Helpers.js
+++ b/Helpers.js
@@ -182,7 +182,7 @@ function tripObjectToRowArray(trip) {
     trip.notes || "",                  // Y
     "", "", "", "", "",                // Z - AD
     trip.returnOf || "",               // AE (index 30)
-    trip.previousId || "",             // AF (index 31)
+    trip.recurringId || "",            // AF (index 31)
     JSON.stringify(trip.standingOrder || {}) // AG (index 32)
   ];
 }
@@ -214,11 +214,11 @@ function convertRowToTrip(row) {
     status: row[16],                   // Q
     vehicle: row[17],                  // R
     driver: row[20],                   // U
+    recurringId: row[31] || "",        // AF
     tripKeyID: row[10],                // K
     id: row[23],                       // X
     notes: row[24],                    // Y
     returnOf: row[30] || "",           // AE
-    previousId: row[31] || "",         // AF
     standingOrder: (() => { try { return JSON.parse(row[32] || '{}'); } catch (e) { return {}; } })()
   };
 }
@@ -239,7 +239,8 @@ function dispatchRowToTripObject(row) {
     vehicle: row[12],            // M: Vehicle
     driver: row[14],             // O: DRIVER
     standingOrder: (() => { try { return JSON.parse(row[32] || '{}'); } catch (e) { return {}; } })(),
-    notes: row[22],              // W: Notes
+    recurringId: row[31] || "",  // AF: recurringId
+    notes: row[24],              // Y: Notes
     returnOf: row[30] || "",     // AE: returnOf (optional)
     status: row[24] || "",       // Y: Status
 

--- a/RecurringTrips.js
+++ b/RecurringTrips.js
@@ -67,7 +67,7 @@ class StandingOrderManager {
       const newId = Utilities.getUuid();
       newFields[0] = dateStr;
       newFields[11] = newId;
-      newFields[22] = recurringId;
+      newFields[31] = recurringId;
       newFields[32] = standingOrder;
       row.entries.push([newId, newFields]);
     });
@@ -88,7 +88,7 @@ class StandingOrderManager {
 
   /**
    * Delete recurring trip instances from specific dates.
-   * @param {string} recurringId Parent tripId stored in fields[22]
+   * @param {string} recurringId Parent tripId stored in fields[31]
    * @param {string[]} datesToDelete Dates to remove (yyyy-MM-dd)
    */
   deleteFromDates(recurringId, datesToDelete) {
@@ -123,7 +123,7 @@ class StandingOrderManager {
       if (!Array.isArray(arr)) return;
       const idx = arr.findIndex(item => {
         const fields = item && item[1];
-        return fields && fields[22] === recurringId;
+        return fields && fields[31] === recurringId;
       });
       if (idx > -1) {
         arr.splice(idx, 1);

--- a/TripsTest.js
+++ b/TripsTest.js
@@ -30,7 +30,7 @@ class TripsTest {
       driver: '',
       notes: 'This is a TEST !!!',
       returnOf: 'orig',
-      previousId: '',
+      recurringId: '',
       standingOrder
     };
     const trip1 = Object.assign({ id: 't1', date: '2024-06-01' }, baseTrip);


### PR DESCRIPTION
## Summary
- store recurringId at former previousId column
- map recurringId from column AF when converting rows
- update RecurringTrips.js to use new column
- remove previousId references

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68621ae1a500832f96e1adec88d60867