### PR TITLE
Fix StandingOrderManager constructor

### DIFF
--- a/RecurringTrips.js
+++ b/RecurringTrips.js
@@ -1,8 +1,8 @@
 // Object-oriented utilities for optimized recurring trip management.
 
 class StandingOrderManager {
-  constructor(service = spreadsheetService) {
-    this.service = service;
+  constructor(service) {
+    this.service = service || spreadsheetService;
   }
 
   get logSheet() {


### PR DESCRIPTION
## Summary
- prevent early evaluation of spreadsheetService by changing constructor default

## Testing
- `noop`


------
https://chatgpt.com/codex/tasks/task_e_6862dbc68ba8832f8b77b7fc4ba40182