### PR TITLE
Fix ID sync for legacy entries

### DIFF
--- a/SideBarSnapShots.js
+++ b/SideBarSnapShots.js
@@ -409,7 +409,7 @@ function backSyncLegacyTripIds() {
       map.forEach((val, key) => {
         const arr = Array.isArray(val) ? val.slice() : tripObjectToRowArray(val);
         let tripKeyID = key || arr[10];
-        if (!tripKeyID) {
+        if (!tripKeyID || tripKeyID === 'null' || tripKeyID === 'undefined') {
           tripKeyID = Utils.generateTripId({
             date: arr[0],
             time: arr[2],


### PR DESCRIPTION
## Summary
- handle null/undefined tripKeyID strings in backSyncLegacyTripIds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68631a98e450832f9d4e82c52b85da2d