### PR TITLE
Update trip map serialization and add tests

### DIFF
--- a/Helpers.js
+++ b/Helpers.js
@@ -32,20 +32,25 @@ function sortTripMapByTime(map) {
 
 /**
  * Serializes a Map of trips to a JSON string. Trips are first ordered by time
- * for consistency, then converted to an array of [id, trip] pairs.
+ * for consistency, then converted to an array of [key, trip] pairs.
  * @param {Map<string, Object>} map
  * @return {string}
  */
 function serializeTripMap(map) {
   if (!(map instanceof Map)) return JSON.stringify([]);
-  const ordered = sortTripObjectsByTime(Array.from(map.values()));
-  const pairs = ordered.map(trip => [trip.id, trip]);
-  return JSON.stringify(pairs);
+  const entries = Array.from(map.entries());
+  entries.sort((a, b) => {
+    const timeA = toTimeOnlySmart(a[1].time || a[1].startTime);
+    const timeB = toTimeOnlySmart(b[1].time || b[1].startTime);
+    return timeA - timeB;
+  });
+  return JSON.stringify(entries);
 }
 
 /**
  * Deserializes a JSON string created by {@link serializeTripMap} back into a
- * Map keyed by trip ID. Falls back gracefully on legacy object/array formats.
+ * Map keyed by the first element of each pair. Falls back gracefully on legacy
+ * object/array formats.
  * @param {string} str
  * @return {Map<string, Object>}
  */

--- a/TripsTest.js
+++ b/TripsTest.js
@@ -51,6 +51,51 @@ class TripsTest {
     DriveApp.getFileById(ss.getId()).setTrashed(true);
   }
 
+  backSyncLogObjectsUsesTripKeyID() {
+    const ss = SpreadsheetApp.create('BackSyncLogObjectsTest');
+    const sheet = ss.getSheets()[0];
+    sheet.setName('LOG');
+    sheet.getRange('A1:B1').setValues([['Date', 'Trips']]);
+
+    const service = new SpreadsheetService({ Dispatcher: ss.getId() });
+    const manager = new TripManager(service, logManager);
+
+    const trip = {
+      id: 't1',
+      tripKeyID: 'key123',
+      date: '2024-07-01',
+      time: '10:00',
+      passenger: 'P',
+      transport: 'V',
+      phone: '555',
+      medicaid: 'M',
+      invoice: 'I',
+      pickup: 'A',
+      dropoff: 'B',
+      status: '',
+      vehicle: '',
+      driver: '',
+      notes: '',
+      returnOf: '',
+      recurringId: ''
+    };
+
+    const map = new Map([['wrong', trip]]);
+    sheet.appendRow(['2024-07-01', serializeTripMap(map)]);
+
+    backSyncLogObjects();
+
+    const updated = deserializeTripMap(sheet.getRange(2, 2).getValue());
+    const key = Array.from(updated.keys())[0];
+    if (key !== 'key123') {
+      throw new Error('backSyncLogObjects did not persist tripKeyID');
+    } else {
+      Logger.log('testBackSyncLogObjectsUsesTripKeyID passed');
+    }
+
+    DriveApp.getFileById(ss.getId()).setTrashed(true);
+  }
+
   testOnEdit() {
     tripManager.testOnEdit();
   }
@@ -85,3 +130,4 @@ function TEST_openEditTripSidebar(id) { tripsTest.openEditTripSidebar(id); }
 function TEST_showEditTripSidebar(id, date) { tripsTest.showEditTripSidebar(id, date); }
 function TEST_openPassengerTripList(date) { tripsTest.openPassengerTripList(date); }
 function TEST_showRestoreDatePicker() { tripsTest.showRestoreDatePicker(); }
+function TEST_backSyncLogObjectsUsesTripKeyID() { tripsTest.backSyncLogObjectsUsesTripKeyID(); }


### PR DESCRIPTION
## Summary
- update serialization of trip maps to use map keys
- sort trips by time while serializing
- clarify deserialization comment
- add test for `backSyncLogObjects` to ensure tripKeyID is used

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863f060b3dc832faca3f6585414b5df