### PR TITLE
Implement standing order map storage

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -107,6 +107,23 @@
       }
 
 
+      function generateTripKeyID() {
+        if (crypto.randomUUID) {
+          return crypto.randomUUID();
+        }
+        const bytes = crypto.getRandomValues(new Uint8Array(16));
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+        const hex = Array.from(bytes).map(b => b.toString(16).padStart(2, '0'));
+        return (
+          hex.slice(0, 4).join('') + '-' +
+          hex.slice(4, 6).join('') + '-' +
+          hex.slice(6, 8).join('') + '-' +
+          hex.slice(8, 10).join('') + '-' +
+          hex.slice(10).join('')
+        );
+      }
+
       function submitNewTrip() {
         document.getElementById("loading-overlay").style.display = "flex";
 
@@ -191,10 +208,12 @@
         }
 
         const tripsToSave = [];
-        expandedDates.forEach(dateStr => {
+        for (const dateStr of expandedDates) {
+          const tripKeyID = generateTripKeyID();
           const t = {
             ...trip,
             date: dateStr,
+            tripKeyID,
             id: `${driver}|${dateStr}|${time}|${passenger}|${pickup}`
           };
           if (isStandingOrder) {
@@ -203,8 +222,10 @@
           tripsToSave.push(t);
 
           if (isReturnTrip && returnTime) {
+            const returnKey = generateTripKeyID();
             const rt = {
               ...t,
+              tripKeyID: returnKey,
               id: `${driver}|${dateStr}|${returnTime}|${passenger}|${dropoff}`,
               time: returnTime,
               pickup: dropoff,
@@ -217,7 +238,7 @@
             }
             tripsToSave.push(rt);
           }
-        });
+        }
 
         google.script.run
           .withSuccessHandler(() => {

--- a/AmazingGraceTransport_constant.js
+++ b/AmazingGraceTransport_constant.js
@@ -27,8 +27,7 @@ const COLUMN = {
     ID: 23,           // X
     NOTES: 24,        // Y
     RETURN_OF: 30,    // AE
-    RECURRING_ID: 31, // AF
-    STANDING_ORDER: 32 // AG
+    RECURRING_ID: 31  // AF
   },
   DISPATCH: {
     TRIP_KEY_ID: 10,  // K
@@ -44,7 +43,6 @@ const COLUMN = {
     DROPOFF: 11,      // L
     VEHICLE: 12,      // M
     DRIVER: 14,       // O
-    STANDING_ORDER: 32, // AG
     RECURRING_ID: 31, // AF
     NOTES: 24,        // Y
     RETURN_OF: 30,    // AE

--- a/EditTripPage.html
+++ b/EditTripPage.html
@@ -152,6 +152,9 @@
         document.getElementById("trip-driver").value = trip.driver || '';
         document.getElementById("trip-status").value = trip.status || '';
         document.getElementById("trip-notes").value = trip.notes || '';
+        google.script.run.withSuccessHandler(map => {
+          currentTrip.standingOrder = map[currentTrip.tripKeyID] || null;
+        }).withFailureHandler(() => {}).getStandingOrderMap();
       }
 
 

--- a/Helpers.js
+++ b/Helpers.js
@@ -79,6 +79,10 @@ function deserializeTripMap(str) {
     });
   }
 
+  map.forEach(val => {
+    if (val && typeof val === 'object') delete val.standingOrder;
+  });
+
   return map;
 }
 
@@ -162,7 +166,7 @@ function formatToYMD(dateString) {
  * [TripIDKEY, tripArray].
  */
 function tripObjectToRowArray(trip) {
-  const row = Array(COLUMN.LOG.STANDING_ORDER + 1).fill("");
+  const row = Array(COLUMN.LOG.RECURRING_ID + 1).fill("");
   row[COLUMN.LOG.DATE] = fromDateOnly(trip.date);
   row[COLUMN.LOG.START_TIME] = toTimeOnlySmart(trip.startTime, { returnMillis: false });
   row[COLUMN.LOG.TIME] = toTimeOnlySmart(trip.time, { returnMillis: false });
@@ -183,7 +187,6 @@ function tripObjectToRowArray(trip) {
   row[COLUMN.LOG.NOTES] = trip.notes || "";
   row[COLUMN.LOG.RETURN_OF] = trip.returnOf || "";
   row[COLUMN.LOG.RECURRING_ID] = trip.recurringId || "";
-  row[COLUMN.LOG.STANDING_ORDER] = JSON.stringify(trip.standingOrder || {});
   return row;
 }
 
@@ -218,8 +221,7 @@ function convertRowToTrip(row) {
     tripKeyID: row[COLUMN.LOG.TRIP_KEY_ID],
     id: row[COLUMN.LOG.ID],
     notes: row[COLUMN.LOG.NOTES],
-    returnOf: row[COLUMN.LOG.RETURN_OF] || "",
-    standingOrder: (() => { try { return JSON.parse(row[COLUMN.LOG.STANDING_ORDER] || '{}'); } catch (e) { return {}; } })()
+    returnOf: row[COLUMN.LOG.RETURN_OF] || ""
   };
 }
 
@@ -238,7 +240,6 @@ function dispatchRowToTripObject(row) {
     dropoff: row[COLUMN.DISPATCH.DROPOFF],            // L: Drop Off
     vehicle: row[COLUMN.DISPATCH.VEHICLE],            // M: Vehicle
     driver: row[COLUMN.DISPATCH.DRIVER],             // O: DRIVER
-    standingOrder: (() => { try { return JSON.parse(row[COLUMN.DISPATCH.STANDING_ORDER] || '{}'); } catch (e) { return {}; } })(),
     recurringId: row[COLUMN.DISPATCH.RECURRING_ID] || "",  // AF: recurringId
     notes: row[COLUMN.DISPATCH.NOTES],              // Y: Notes
     returnOf: row[COLUMN.DISPATCH.RETURN_OF] || "",     // AE: returnOf (optional)

--- a/RecurringTrips.js
+++ b/RecurringTrips.js
@@ -23,14 +23,10 @@ class StandingOrderManager {
 
     const parentFields = parentTrip[1];
     const recurringId = parentFields[11];
-    const standingOrderJson = parentFields[32];
-    let standingOrderObj = {};
-    try {
-      standingOrderObj = JSON.parse(standingOrderJson || '{}');
-    } catch (e) {
-      standingOrderObj = {};
-    }
-    parentFields[32] = standingOrderJson;
+    const tripKeyID = parentFields[10];
+    const soMap = tripManager.getStandingOrderMap();
+    const standingOrderObj = soMap[tripKeyID] || {};
+    soMap[tripKeyID] = standingOrderObj;
 
     const lastRow = logSheet.getLastRow();
     const data = lastRow > 1 ? logSheet.getRange(2, 1, lastRow - 1, 2).getValues() : [];
@@ -73,7 +69,6 @@ class StandingOrderManager {
       newFields[0] = dateStr;
       newFields[11] = newId;
       newFields[31] = recurringId;
-      newFields[32] = standingOrderJson;
       const newTrip = convertRowToTrip(newFields);
       newTrip.id = newId;
       row.map.set(newId, newTrip);
@@ -89,7 +84,6 @@ class StandingOrderManager {
         returnFields[24] = ((returnFields[24] || '') + ' [RETURN TRIP]').trim();
         returnFields[30] = newId;
         returnFields[31] = recurringId;
-        returnFields[32] = standingOrderJson;
         const returnTrip = convertRowToTrip(returnFields);
         returnTrip.id = returnId;
         row.map.set(returnId, returnTrip);
@@ -101,6 +95,7 @@ class StandingOrderManager {
       logSheet.getRange(info.index, 1, 1, 2)
         .setValues([[key, serializeTripMap(info.map)]]);
     }
+    tripManager.updateStandingOrderMap(soMap);
   }
 
   /**

--- a/SideBarSnapShots.js
+++ b/SideBarSnapShots.js
@@ -397,14 +397,7 @@ function backSyncLegacyTripIds() {
             map = new Map();
             arr.forEach(r => {
               if (!Array.isArray(r)) return;
-              const tripKeyID = Utils.generateTripId({
-                date: r[0],
-                time: r[2],
-                passenger: r[3],
-                phone: r[6],
-                pickup: r[9],
-                dropoff: r[12]
-              });
+              const tripKeyID = Utilities.getUuid();
               r[10] = tripKeyID;
               map.set(tripKeyID, r);
             });
@@ -420,14 +413,7 @@ function backSyncLegacyTripIds() {
         const arr = Array.isArray(val) ? val.slice() : tripObjectToRowArray(val);
         let tripKeyID = key || arr[10];
         if (!tripKeyID || tripKeyID === 'null' || tripKeyID === 'undefined') {
-          tripKeyID = Utils.generateTripId({
-            date: arr[0],
-            time: arr[2],
-            passenger: arr[3],
-            phone: arr[6],
-            pickup: arr[9],
-            dropoff: arr[12]
-          });
+          tripKeyID = Utilities.getUuid();
         }
         arr[10] = tripKeyID;
         updatedMap.set(tripKeyID, arr);


### PR DESCRIPTION
## Summary
- manage standing orders via JSON map stored in LOG!A1
- drop STANDING_ORDER column constants
- keep standing order data out of trip objects when serializing/deserializing
- compute TripKeyID client-side when adding trips
- fetch standing order info for editing and recurring trip generation
- generate TripKeyID with uuid

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686452487c20832fab8bdb83e80fc6ae