### PR TITLE
Fix loading overlay hide calls

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -178,12 +178,12 @@
           const end = parseLocalDate(trip.standingOrder.endDate);
           if (end < start) {
             alert("🚫 Standing order end date cannot be before start date.");
-            overlay.style.display = "none";
+            document.getElementById("loading-overlay").style.display = "none";
             return;
           }
           if ((end - start) / 86400000 > 183) {
             alert("🚫 Standing order cannot exceed 183 days.");
-            overlay.style.display = "none";
+            document.getElementById("loading-overlay").style.display = "none";
             return;
           }
         }


### PR DESCRIPTION
## Summary
- ensure hiding overlay uses DOM query in AddTripPage

## Testing
- `grep -n overlay.style.display -n AddTripPage.html`

------
https://chatgpt.com/codex/tasks/task_e_686457b00d2c832fa91afddd76d5dd5e