### PR TITLE
Update standing order handling

### DIFF
--- a/RecurringTrips.js
+++ b/RecurringTrips.js
@@ -22,11 +22,11 @@ class StandingOrderManager {
     if (!logSheet) return;
 
     const parentFields = parentTrip[1];
-    const recurringId = parentFields[11];
+    const recurringId = parentFields[31];
     const tripKeyID = parentFields[10];
     const soMap = tripManager.getStandingOrderMap();
-    const standingOrderObj = soMap[tripKeyID] || {};
-    soMap[tripKeyID] = standingOrderObj;
+    const standingOrderObj = soMap[recurringId] || {};
+    soMap[recurringId] = standingOrderObj;
 
     const lastRow = logSheet.getLastRow();
     const data = lastRow > 1 ? logSheet.getRange(2, 1, lastRow - 1, 2).getValues() : [];
@@ -67,7 +67,7 @@ class StandingOrderManager {
       const newFields = parentFields.slice();
       const newId = Utilities.getUuid();
       newFields[0] = dateStr;
-      newFields[11] = newId;
+      newFields[23] = newId;
       newFields[31] = recurringId;
       const newTrip = convertRowToTrip(newFields);
       newTrip.id = newId;
@@ -77,7 +77,7 @@ class StandingOrderManager {
         const returnFields = parentFields.slice();
         const returnId = Utilities.getUuid();
         returnFields[0] = dateStr;
-        returnFields[11] = returnId;
+        returnFields[23] = returnId;
         returnFields[2] = standingOrderObj.returnTime;
         returnFields[9] = parentFields[12];
         returnFields[12] = parentFields[9];

--- a/TripManager.js
+++ b/TripManager.js
@@ -109,10 +109,13 @@ class TripManager {
     if (!trip.tripKeyID) {
       trip.tripKeyID = Utilities.getUuid();
     }
-    if (trip.standingOrder && trip.tripKeyID) {
-      const soMap = this.getStandingOrderMap();
-      soMap[trip.tripKeyID] = trip.standingOrder;
-      this.updateStandingOrderMap(soMap);
+    if (trip.standingOrder) {
+      const soKey = trip.recurringId || trip.tripKeyID;
+      if (soKey) {
+        const soMap = this.getStandingOrderMap();
+        soMap[soKey] = trip.standingOrder;
+        this.updateStandingOrderMap(soMap);
+      }
     }
     delete trip.standingOrder;
     const sheet = this.logSheet;
@@ -221,10 +224,13 @@ class TripManager {
     if (!trip.tripKeyID) {
       trip.tripKeyID = Utilities.getUuid();
     }
-    if (trip.standingOrder && trip.tripKeyID) {
-      const soMap = this.getStandingOrderMap();
-      soMap[trip.tripKeyID] = trip.standingOrder;
-      this.updateStandingOrderMap(soMap);
+    if (trip.standingOrder) {
+      const soKey = trip.recurringId || trip.tripKeyID;
+      if (soKey) {
+        const soMap = this.getStandingOrderMap();
+        soMap[soKey] = trip.standingOrder;
+        this.updateStandingOrderMap(soMap);
+      }
     }
     delete trip.standingOrder;
     const normalizedDate = Utils.formatDateString(trip.date || '');


### PR DESCRIPTION
## Summary
- handle standing orders by recurringId rather than per-trip key
- fix recurring trip creation logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865222e2680832fa8e1d14d9d0986eb