### PR TITLE
Add date pattern standing order map

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -166,16 +166,17 @@
         };
 
         const isStandingOrder = document.getElementById("standing-order-checkbox")?.checked;
+        let standingOrder = null;
         if (isStandingOrder) {
-          trip.standingOrder = {
+          standingOrder = {
             frequency: document.getElementById("standing-frequency").value,
             startDate: document.getElementById("standing-start-date").value,
             endDate: document.getElementById("standing-end-date").value,
             days: Array.from(document.querySelectorAll("#custom-days input:checked"))
               .map(cb => cb.value)
           };
-          const start = parseLocalDate(trip.standingOrder.startDate);
-          const end = parseLocalDate(trip.standingOrder.endDate);
+          const start = parseLocalDate(standingOrder.startDate);
+          const end = parseLocalDate(standingOrder.endDate);
           if (end < start) {
             alert("🚫 Standing order end date cannot be before start date.");
             document.getElementById("loading-overlay").style.display = "none";
@@ -198,13 +199,39 @@
           return;
         }
 
-        const expandedDates = expandStandingOrder(trip);
+        let expandedDates = [date];
         if (isStandingOrder) {
-          trip.standingOrder.dates = expandedDates;
-          trip.standingOrder.withReturnTrip = isReturnTrip;
-          if (isReturnTrip && returnTime) {
-            trip.standingOrder.returnTime = returnTime;
+          const dayNames = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+          const freq = standingOrder.frequency;
+          const startDay = dayNames[parseLocalDate(standingOrder.startDate).getDay()];
+          let daysForPattern = [];
+          switch (freq) {
+            case "DAILY":
+              daysForPattern = dayNames;
+              break;
+            case "WEEKDAYS":
+              daysForPattern = dayNames.slice(1, 6);
+              break;
+            case "WEEKENDS":
+              daysForPattern = [dayNames[0], dayNames[6]];
+              break;
+            default:
+              daysForPattern = standingOrder.days.length
+                ? standingOrder.days
+                : [startDay];
           }
+          const pattern = encodeDatePattern(
+            standingOrder.startDate,
+            standingOrder.endDate,
+            daysForPattern
+          );
+          standingOrder = {
+            ...standingOrder,
+            pattern,
+            withReturnTrip: isReturnTrip,
+            ...(isReturnTrip && returnTime ? { returnTime } : {})
+          };
+          expandedDates = decodeDatePattern(pattern);
         }
 
         const tripsToSave = [];
@@ -219,9 +246,6 @@
             id: `${driver}|${dateStr}|${time}|${passenger}|${pickup}`,
             recurringId: parentTripKeyID
           };
-          if (isStandingOrder) {
-            t.standingOrder = { ...trip.standingOrder };
-          }
           tripsToSave.push(t);
 
           if (isReturnTrip && returnTime) {
@@ -237,20 +261,40 @@
               returnOf: t.id,
               recurringId: parentTripKeyID
             };
-            if (isStandingOrder) {
-              rt.standingOrder = { ...trip.standingOrder };
-            }
             tripsToSave.push(rt);
           }
         }
 
-        google.script.run
-          .withSuccessHandler(() => {
-            document.getElementById("loading-overlay").style.display = "none";
-            google.script.run.withSuccessHandler().withFailureHandler(handleError).openPassengerTripList(date);
-          })
-          .withFailureHandler(handleError)
-          .addTripToLog(tripsToSave);
+        function finalize() {
+          document.getElementById("loading-overlay").style.display = "none";
+          google.script.run
+            .withSuccessHandler()
+            .withFailureHandler(handleError)
+            .openPassengerTripList(date);
+        }
+
+        if (isStandingOrder && standingOrder) {
+          google.script.run
+            .withSuccessHandler(map => {
+              map[parentTripKeyID] = standingOrder;
+              google.script.run
+                .withSuccessHandler(() => {
+                  google.script.run
+                    .withSuccessHandler(finalize)
+                    .withFailureHandler(handleError)
+                    .addTripToLog(tripsToSave);
+                })
+                .withFailureHandler(handleError)
+                .updateStandingOrderMap(map);
+            })
+            .withFailureHandler(handleError)
+            .getStandingOrderMap();
+        } else {
+          google.script.run
+            .withSuccessHandler(finalize)
+            .withFailureHandler(handleError)
+            .addTripToLog(tripsToSave);
+        }
       }
 
     </script>

--- a/SharedLoaders.html
+++ b/SharedLoaders.html
@@ -150,8 +150,47 @@
     return new Date(y, m - 1, d);
   }
 
+  function encodeDatePattern(startDate, endDate, daysOfWeek) {
+    const days = Array.isArray(daysOfWeek)
+      ? daysOfWeek.map(d => d.toUpperCase()).join(',')
+      : '';
+    return [startDate, endDate, days].join('|');
+  }
+
+  function decodeDatePattern(patternStr) {
+    if (!patternStr) return [];
+    const [startStr, endStr, daysStr] = patternStr.split('|');
+    if (!startStr || !endStr || !daysStr) return [];
+
+    const dayMap = {
+      SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6,
+    };
+    const dayNums = daysStr
+      .split(',')
+      .map(d => dayMap[d.trim().toUpperCase()])
+      .filter(d => d !== undefined);
+    if (dayNums.length === 0) return [];
+
+    const [sy, sm, sd] = startStr.split('-').map(Number);
+    const [ey, em, ed] = endStr.split('-').map(Number);
+    const start = new Date(sy, sm - 1, sd);
+    const end = new Date(ey, em - 1, ed);
+
+    const dates = [];
+    for (let cur = new Date(start); cur <= end; cur.setDate(cur.getDate() + 1)) {
+      if (dayNums.includes(cur.getDay())) {
+        dates.push(cur.toISOString().slice(0, 10));
+      }
+    }
+    return dates;
+  }
+
   function expandStandingOrder(trip) {
     if (!trip || !trip.standingOrder) return trip && trip.date ? [trip.date] : [];
+
+    if (trip.standingOrder.pattern) {
+      return decodeDatePattern(trip.standingOrder.pattern);
+    }
 
     const { startDate, endDate, frequency, days = [] } = trip.standingOrder;
     if (!startDate || !endDate) return trip.date ? [trip.date] : [];

--- a/TripManager.js
+++ b/TripManager.js
@@ -103,21 +103,9 @@ class TripManager {
       return;
     }
     trip.time = this.normalizeTimeString(trip.time);
-    if (trip.standingOrder && trip.standingOrder.returnTime) {
-      trip.standingOrder.returnTime = this.normalizeTimeString(trip.standingOrder.returnTime);
-    }
     if (!trip.tripKeyID) {
       trip.tripKeyID = Utilities.getUuid();
     }
-    if (trip.standingOrder) {
-      const soKey = trip.recurringId || trip.tripKeyID;
-      if (soKey) {
-        const soMap = this.getStandingOrderMap();
-        soMap[soKey] = trip.standingOrder;
-        this.updateStandingOrderMap(soMap);
-      }
-    }
-    delete trip.standingOrder;
     const sheet = this.logSheet;
     for (const k in logIndexCache) delete logIndexCache[k];
     const allData = sheet.getRange('A2:B101').getValues();
@@ -218,21 +206,9 @@ class TripManager {
     const jsonCol = 2;
     if (!trip?.id) return;
     trip.time = this.normalizeTimeString(trip.time);
-    if (trip.standingOrder && trip.standingOrder.returnTime) {
-      trip.standingOrder.returnTime = this.normalizeTimeString(trip.standingOrder.returnTime);
-    }
     if (!trip.tripKeyID) {
       trip.tripKeyID = Utilities.getUuid();
     }
-    if (trip.standingOrder) {
-      const soKey = trip.recurringId || trip.tripKeyID;
-      if (soKey) {
-        const soMap = this.getStandingOrderMap();
-        soMap[soKey] = trip.standingOrder;
-        this.updateStandingOrderMap(soMap);
-      }
-    }
-    delete trip.standingOrder;
     const normalizedDate = Utils.formatDateString(trip.date || '');
     const today = new Date();
     today.setHours(0, 0, 0, 0);

--- a/TripsTest.js
+++ b/TripsTest.js
@@ -12,8 +12,14 @@ class TripsTest {
       frequency: 'DAILY',
       startDate: '2024-06-01',
       endDate: '2024-06-05',
-      days: ['MO', 'TU', 'WE', 'TH', 'FR']
+      days: ['MO', 'TU', 'WE', 'TH', 'FR'],
+      pattern: encodeDatePattern('2024-06-01', '2024-06-05', ['MO', 'TU', 'WE', 'TH', 'FR'])
     };
+
+    const soMap = {};
+    const soKey = 'so1';
+    soMap[soKey] = standingOrder;
+    manager.updateStandingOrderMap(soMap);
 
     const baseTrip = {
       date: '2024-06-01',
@@ -30,8 +36,7 @@ class TripsTest {
       driver: '',
       notes: 'This is a TEST !!!',
       returnOf: 'orig',
-      recurringId: '',
-      standingOrder
+      recurringId: soKey
     };
     const trip1 = Object.assign({ id: 't1', date: '2024-06-01' }, baseTrip);
     const trip2 = Object.assign({ id: 't2', date: '2024-06-02' }, baseTrip);


### PR DESCRIPTION
## Summary
- remove storing standing order info on trips
- compute standing order pattern client side and persist in A1 map
- assign standing order tripKeyID to recurringId for generated trips
- update test fixture for new standing order logic

## Testing
- `npm test` *(fails: could not find package.json)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6866073df460832f93854252d560d0d0