### PR TITLE
Refactor standing order pattern storage

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -168,15 +168,15 @@
         const isStandingOrder = document.getElementById("standing-order-checkbox")?.checked;
         let standingOrder = null;
         if (isStandingOrder) {
-          standingOrder = {
-            frequency: document.getElementById("standing-frequency").value,
-            startDate: document.getElementById("standing-start-date").value,
-            endDate: document.getElementById("standing-end-date").value,
-            days: Array.from(document.querySelectorAll("#custom-days input:checked"))
-              .map(cb => cb.value)
-          };
-          const start = parseLocalDate(standingOrder.startDate);
-          const end = parseLocalDate(standingOrder.endDate);
+          const frequency = document.getElementById("standing-frequency").value;
+          const startDate = document.getElementById("standing-start-date").value;
+          const endDate = document.getElementById("standing-end-date").value;
+          const selectedDays = Array.from(
+            document.querySelectorAll("#custom-days input:checked")
+          ).map(cb => cb.value);
+
+          const start = parseLocalDate(startDate);
+          const end = parseLocalDate(endDate);
           if (end < start) {
             alert("🚫 Standing order end date cannot be before start date.");
             document.getElementById("loading-overlay").style.display = "none";
@@ -202,8 +202,8 @@
         let expandedDates = [date];
         if (isStandingOrder) {
           const dayNames = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
-          const freq = standingOrder.frequency;
-          const startDay = dayNames[parseLocalDate(standingOrder.startDate).getDay()];
+          const freq = frequency;
+          const startDay = dayNames[parseLocalDate(startDate).getDay()];
           let daysForPattern = [];
           switch (freq) {
             case "DAILY":
@@ -216,17 +216,16 @@
               daysForPattern = [dayNames[0], dayNames[6]];
               break;
             default:
-              daysForPattern = standingOrder.days.length
-                ? standingOrder.days
+              daysForPattern = selectedDays.length
+                ? selectedDays
                 : [startDay];
           }
           const pattern = encodeDatePattern(
-            standingOrder.startDate,
-            standingOrder.endDate,
+            startDate,
+            endDate,
             daysForPattern
           );
           standingOrder = {
-            ...standingOrder,
             pattern,
             withReturnTrip: isReturnTrip,
             ...(isReturnTrip && returnTime ? { returnTime } : {})

--- a/SharedLoaders.html
+++ b/SharedLoaders.html
@@ -192,46 +192,6 @@
       return decodeDatePattern(trip.standingOrder.pattern);
     }
 
-    const { startDate, endDate, frequency, days = [] } = trip.standingOrder;
-    if (!startDate || !endDate) return trip.date ? [trip.date] : [];
-
-    const start = parseLocalDate(startDate);
-    const end = parseLocalDate(endDate);
-    const dayNames = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
-    const results = [];
-
-    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-      const dayName = dayNames[d.getDay()];
-      const diffDays = Math.floor((d - start) / 86400000);
-      let include = false;
-      switch (frequency) {
-        case "DAILY":
-          include = true;
-          break;
-        case "WEEKDAYS":
-          include = d.getDay() >= 1 && d.getDay() <= 5;
-          break;
-        case "WEEKENDS":
-          include = d.getDay() === 0 || d.getDay() === 6;
-          break;
-        case "WEEKLY":
-          include = days.length ? days.includes(dayName) : dayName === dayNames[start.getDay()];
-          break;
-        case "BIWEEKLY":
-          include = (days.length ? days.includes(dayName) : dayName === dayNames[start.getDay()]) && Math.floor(diffDays / 7) % 2 === 0;
-          break;
-        case "MONTHLY":
-          include = d.getDate() === start.getDate();
-          if (days.length) include = include && days.includes(dayName);
-          break;
-        default:
-          include = true;
-      }
-      if (include) {
-        results.push(d.toISOString().slice(0, 10));
-      }
-    }
-
-    return results;
+    return trip.date ? [trip.date] : [];
   }
 </script>

--- a/TripsTest.js
+++ b/TripsTest.js
@@ -9,11 +9,13 @@ class TripsTest {
     const manager = new TripManager(service, logManager);
 
     const standingOrder = {
-      frequency: 'DAILY',
-      startDate: '2024-06-01',
-      endDate: '2024-06-05',
-      days: ['MO', 'TU', 'WE', 'TH', 'FR'],
-      pattern: encodeDatePattern('2024-06-01', '2024-06-05', ['MO', 'TU', 'WE', 'TH', 'FR'])
+      pattern: encodeDatePattern(
+        '2024-06-01',
+        '2024-06-05',
+        ['MO', 'TU', 'WE', 'TH', 'FR']
+      ),
+      withReturnTrip: true,
+      returnTime: '1899-12-30T14:40:00Z'
     };
 
     const soMap = {};


### PR DESCRIPTION
## Summary
- simplify standing order creation on AddTripPage to only store pattern, withReturnTrip and returnTime
- adjust TripsTest example to match new structure
- decode standing orders only from pattern in SharedLoaders

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68668841cf28832fa10ecc33781c8cca