### PR TITLE
Fix standing order deletion by recurringId

### DIFF
--- a/TripManager.js
+++ b/TripManager.js
@@ -322,10 +322,10 @@ class TripManager {
     const allTrips = this.getAllTrips();
     const target = JSON.stringify(standingOrder);
     allTrips.forEach(trip => {
-      const so = soMap[trip.tripKeyID] || {};
+      const so = soMap[trip.recurringId] || {};
       if (JSON.stringify(so) === target) {
         this.deleteTripFromLog(trip.tripKeyID, trip.date);
-        delete soMap[trip.tripKeyID];
+        delete soMap[trip.recurringId];
       }
     });
     this.updateStandingOrderMap(soMap);
@@ -338,13 +338,13 @@ class TripManager {
     const allTrips = this.getAllTrips();
     const target = JSON.stringify(standingOrder);
     allTrips.forEach(trip => {
-      const so = soMap[trip.tripKeyID] || {};
+      const so = soMap[trip.recurringId] || {};
       if (
         JSON.stringify(so) === target &&
         normalizedDates.includes(Utils.formatDateString(trip.date))
       ) {
         this.deleteTripFromLog(trip.tripKeyID, trip.date);
-        delete soMap[trip.tripKeyID];
+        delete soMap[trip.recurringId];
       }
     });
     this.updateStandingOrderMap(soMap);


### PR DESCRIPTION
## Summary
- delete standing orders by `recurringId` instead of `tripKeyID`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866e5324608832fbeb7b4c18f1b2256