### PR TITLE
Refactor standing order lookup in edit page

### DIFF
--- a/EditTripPage.html
+++ b/EditTripPage.html
@@ -153,7 +153,7 @@
         document.getElementById("trip-status").value = trip.status || '';
         document.getElementById("trip-notes").value = trip.notes || '';
         google.script.run.withSuccessHandler(map => {
-          currentTrip.standingOrder = map[currentTrip.tripKeyID] || null;
+          map[currentTrip.recurringId];
         }).withFailureHandler(() => {}).getStandingOrderMap();
       }
 
@@ -227,18 +227,20 @@
       function openDeleteModal() {
         const container = document.getElementById("standing-dates");
         container.innerHTML = "";
-        const dates = expandStandingOrder(currentTrip);
-        dates.forEach(d => {
-          const label = document.createElement("label");
-          const cb = document.createElement("input");
-          cb.type = "checkbox";
-          cb.value = d;
-          cb.checked = true;
-          label.appendChild(cb);
-          label.append(" " + d);
-          container.appendChild(label);
-        });
-        document.getElementById("delete-modal").classList.remove("hidden");
+        google.script.run.withSuccessHandler(map => {
+          const dates = expandStandingOrder(currentTrip.recurringId, map);
+          dates.forEach(d => {
+            const label = document.createElement("label");
+            const cb = document.createElement("input");
+            cb.type = "checkbox";
+            cb.value = d;
+            cb.checked = true;
+            label.appendChild(cb);
+            label.append(" " + d);
+            container.appendChild(label);
+          });
+          document.getElementById("delete-modal").classList.remove("hidden");
+        }).getStandingOrderMap();
       }
 
       function closeDeleteModal() {

--- a/SharedLoaders.html
+++ b/SharedLoaders.html
@@ -185,13 +185,12 @@
     return dates;
   }
 
-  function expandStandingOrder(trip) {
-    if (!trip || !trip.standingOrder) return trip && trip.date ? [trip.date] : [];
-
-    if (trip.standingOrder.pattern) {
-      return decodeDatePattern(trip.standingOrder.pattern);
+  function expandStandingOrder(recurringId, map) {
+    if (!recurringId || !map) return [];
+    const standingOrder = map[recurringId];
+    if (standingOrder && standingOrder.pattern) {
+      return decodeDatePattern(standingOrder.pattern);
     }
-
-    return trip.date ? [trip.date] : [];
+    return [];
   }
 </script>


### PR DESCRIPTION
## Summary
- use recurring ID for standing order lookups in EditTripPage
- fetch standing order map on demand when deleting
- simplify expandStandingOrder to accept recurringId

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866fa44b548832fbac2ca88e56b29fb