### PR TITLE
Add duplicate trip detection

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -275,28 +275,53 @@
             .openPassengerTripList(date);
         }
 
-        if (isStandingOrder && standingOrder) {
-          google.script.run
-            .withSuccessHandler(map => {
-              map[parentTripKeyID] = standingOrder;
-              google.script.run
-                .withSuccessHandler(() => {
-                  google.script.run
-                    .withSuccessHandler(finalize)
-                    .withFailureHandler(handleError)
-                    .addTripToLog(tripsToSave);
-                })
-                .withFailureHandler(handleError)
-                .updateStandingOrderMap(map);
-            })
-            .withFailureHandler(handleError)
-            .getStandingOrderMap();
-        } else {
-          google.script.run
-            .withSuccessHandler(finalize)
-            .withFailureHandler(handleError)
-            .addTripToLog(tripsToSave);
+        function saveTrips() {
+          if (isStandingOrder && standingOrder) {
+            google.script.run
+              .withSuccessHandler(map => {
+                map[parentTripKeyID] = standingOrder;
+                google.script.run
+                  .withSuccessHandler(() => {
+                    google.script.run
+                      .withSuccessHandler(finalize)
+                      .withFailureHandler(handleError)
+                      .addTripToLog(tripsToSave);
+                  })
+                  .withFailureHandler(handleError)
+                  .updateStandingOrderMap(map);
+              })
+              .withFailureHandler(handleError)
+              .getStandingOrderMap();
+          } else {
+            google.script.run
+              .withSuccessHandler(finalize)
+              .withFailureHandler(handleError)
+              .addTripToLog(tripsToSave);
+          }
         }
+
+        const duplicateChecks = tripsToSave.map(t =>
+          new Promise((resolve, reject) => {
+            google.script.run
+              .withSuccessHandler(res => resolve(res))
+              .withFailureHandler(err => reject(err))
+              .checkDuplicateTrip(t);
+          })
+        );
+
+        Promise.all(duplicateChecks)
+          .then(results => {
+            if (results.some(r => r)) {
+              alert("🚫 Duplicate trip detected.");
+              document.getElementById("loading-overlay").style.display = "none";
+              return;
+            }
+            saveTrips();
+          })
+          .catch(err => {
+            document.getElementById("loading-overlay").style.display = "none";
+            handleError(err);
+          });
       }
 
     </script>

--- a/TripManager.js
+++ b/TripManager.js
@@ -184,6 +184,23 @@ class TripManager {
     return row || {};
   }
 
+  /**
+   * Check if a trip already exists on the given date. Duplicates are
+   * identified either by matching the full trip id or by matching a variant
+   * that ignores the driver portion of the id.
+   * @param {Object} trip Trip object to compare
+   * @return {boolean} True if a duplicate exists
+   */
+  isDuplicateTrip(trip) {
+    if (!trip || !trip.date) return false;
+    const trips = this.getTripsByDate(Utils.formatDateString(trip.date));
+    const altId = `|${Utils.formatDateString(trip.date)}|${trip.time}|${trip.passenger}|${trip.pickup}`;
+    return trips.some(t => {
+      const matchAlt = `|${Utils.formatDateString(t.date)}|${t.time}|${t.passenger}|${t.pickup}`;
+      return t.id === trip.id || matchAlt === altId;
+    });
+  }
+
   getAllTrips() {
     const sheet = this.logSheet;
     const data = sheet.getRange('A2:B').getValues();
@@ -401,3 +418,4 @@ function deleteStandingOrder(standingOrder) { return tripManager.deleteStandingO
 function deleteStandingOrderOnDates(recurringId, dates) { return tripManager.deleteStandingOrderOnDates(recurringId, dates); }
 function getStandingOrderMap() { return tripManager.getStandingOrderMap(); }
 function updateStandingOrderMap(map) { return tripManager.updateStandingOrderMap(map); }
+function checkDuplicateTrip(trip) { return tripManager.isDuplicateTrip(trip); }


### PR DESCRIPTION
## Summary
- add `isDuplicateTrip()` to TripManager
- export duplicate check server function
- check for existing trips before saving on Add Trip page

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68670ef782dc832f857707a627d83819