### PR TITLE
Add passenger conflict check

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -317,23 +317,45 @@
               return;
             }
 
-            const conflictChecks = tripsToSave.map(t =>
+            const passengerChecks = tripsToSave.map(t =>
               new Promise((resolve, reject) => {
                 google.script.run
                   .withSuccessHandler(res => resolve(res))
                   .withFailureHandler(err => reject(err))
-                  .checkDriverConflict(t);
+                  .checkPassengerConflict(t);
               })
             );
 
-            Promise.all(conflictChecks)
-              .then(cResults => {
-                if (cResults.some(r => r)) {
-                  alert("🚫 Driver has a conflicting trip at that time.");
+            Promise.all(passengerChecks)
+              .then(pResults => {
+                if (pResults.some(r => r)) {
+                  alert("🚫 Passenger has a conflicting trip at that time.");
                   document.getElementById("loading-overlay").style.display = "none";
                   return;
                 }
-                saveTrips();
+
+                const conflictChecks = tripsToSave.map(t =>
+                  new Promise((resolve, reject) => {
+                    google.script.run
+                      .withSuccessHandler(res => resolve(res))
+                      .withFailureHandler(err => reject(err))
+                      .checkDriverConflict(t);
+                  })
+                );
+
+                Promise.all(conflictChecks)
+                  .then(cResults => {
+                    if (cResults.some(r => r)) {
+                      alert("🚫 Driver has a conflicting trip at that time.");
+                      document.getElementById("loading-overlay").style.display = "none";
+                      return;
+                    }
+                    saveTrips();
+                  })
+                  .catch(err => {
+                    document.getElementById("loading-overlay").style.display = "none";
+                    handleError(err);
+                  });
               })
               .catch(err => {
                 document.getElementById("loading-overlay").style.display = "none";

--- a/TripManager.js
+++ b/TripManager.js
@@ -219,6 +219,27 @@ class TripManager {
     });
   }
 
+  /**
+   * Determine if the given trip conflicts with another trip for the same
+   * passenger at the same time on the same day.
+   * @param {Object} trip Trip object to compare
+   * @return {boolean} True if a conflict exists
+   */
+  hasPassengerConflict(trip) {
+    if (!trip || !trip.date || !trip.passenger) return false;
+    const dateKey = Utils.formatDateString(trip.date);
+    const timeKey = this.normalizeTimeString(trip.time);
+    const passenger = (trip.passenger || '').toString().trim();
+    const trips = this.getTripsByDate(dateKey);
+    return trips.some(t => {
+      const tTime = this.normalizeTimeString(t.time);
+      return (
+        tTime === timeKey &&
+        (t.passenger || '').toString().trim() === passenger
+      );
+    });
+  }
+
   getAllTrips() {
     const sheet = this.logSheet;
     const data = sheet.getRange('A2:B').getValues();
@@ -438,3 +459,4 @@ function getStandingOrderMap() { return tripManager.getStandingOrderMap(); }
 function updateStandingOrderMap(map) { return tripManager.updateStandingOrderMap(map); }
 function checkDuplicateTrip(trip) { return tripManager.isDuplicateTrip(trip); }
 function checkDriverConflict(trip) { return tripManager.hasDriverConflict(trip); }
+function checkPassengerConflict(trip) { return tripManager.hasPassengerConflict(trip); }


### PR DESCRIPTION
## Summary
- add `hasPassengerConflict` in TripManager
- export new method for server-side use
- check for passenger conflicts before saving trips in AddTripPage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867131a9e28832fb17604569cbb2323