### PR TITLE
Fix conditional recurringId assignment

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -260,7 +260,7 @@
             date: dateStr,
             tripKeyID,
             id: `${driver}|${dateStr}|${time}|${passenger}|${pickup}`,
-            recurringId: parentTripKeyID
+            ...(isStandingOrder ? { recurringId: parentTripKeyID } : {})
           };
           tripsToSave.push(t);
 
@@ -275,7 +275,7 @@
               dropoff: pickup,
               notes: (t.notes || "") + " [RETURN TRIP]",
               returnOf: t.id,
-              recurringId: parentTripKeyID
+              ...(isStandingOrder ? { recurringId: parentTripKeyID } : {})
             };
             tripsToSave.push(rt);
           }


### PR DESCRIPTION
## Summary
- conditionally assign `recurringId` only when creating standing orders
- keep the same logic for both the main and return trips

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68675bfdc2f0832fb305654a9e53b968