### PR TITLE
Disable save buttons on invalid form

### DIFF
--- a/AddTripPage.html
+++ b/AddTripPage.html
@@ -15,7 +15,7 @@
 
       <?!= include('TripFormFields') ?>
 
-      <button onclick="submitNewTrip()" class="save-button">➕ Add Trip</button>
+      <button onclick="submitNewTrip()" class="save-button" disabled>➕ Add Trip</button>
     </div>
 
     <?!= include('SharedLoaders') ?>
@@ -23,6 +23,16 @@
     <script>
       const initialDate = <?= JSON.stringify(initialDate) ?>;
       let passengerProfiles = {};
+
+      function checkFormValidity() {
+        const requiredFields = document.querySelectorAll('.trip-form [required]');
+        const saveBtn = document.querySelector('.save-button');
+        const allValid = Array.from(requiredFields).every(f => f.value.trim());
+        if (saveBtn) {
+          saveBtn.disabled = !allValid;
+          saveBtn.classList.toggle('disabled', !allValid);
+        }
+      }
 
       document.addEventListener("DOMContentLoaded", () => {
         const date = JSON.parse(initialDate) || new Date().toISOString().slice(0, 10);
@@ -35,6 +45,12 @@
           const name = document.getElementById("trip-passenger").value;
           if (name) syncPassengerProfile(name);
         }, 150);
+
+        checkFormValidity();
+        document.querySelectorAll('.trip-form input, .trip-form select, .trip-form textarea').forEach(el => {
+          el.addEventListener('input', checkFormValidity);
+          el.addEventListener('change', checkFormValidity);
+        });
       });
 
 

--- a/EditTripPage.html
+++ b/EditTripPage.html
@@ -16,7 +16,7 @@
 
       <?!= include('TripFormFields') ?>
 
-      <button class="save-button" style="display:none;" onclick="submitTrip()">💾 Save Trip</button>
+      <button class="save-button" style="display:none;" onclick="submitTrip()" disabled>💾 Save Trip</button>
 
     </div>
 
@@ -37,6 +37,16 @@
       const rawTripId = <?= JSON.stringify(tripId) ?>.replace(/^"+|"+$/g, '');
       const rawTripDate = <?= JSON.stringify(tripDate) ?>.replace(/^"+|"+$/g, '');
       let currentTrip = null;
+
+      function checkFormValidity() {
+        const requiredFields = document.querySelectorAll('.trip-form [required]');
+        const saveBtn = document.querySelector('.save-button');
+        const allValid = Array.from(requiredFields).every(f => f.value.trim());
+        if (saveBtn) {
+          saveBtn.disabled = !allValid;
+          saveBtn.classList.toggle('disabled', !allValid);
+        }
+      }
 
       document.addEventListener("DOMContentLoaded", () => {
         // Hide add-trip only checkboxes
@@ -64,6 +74,12 @@
           .getTripById(safeId, safeDate);
 
         loadTripFormData(); // 🔁 Load passengers, vehicles, and drivers
+
+        checkFormValidity();
+        document.querySelectorAll('.trip-form input, .trip-form select, .trip-form textarea').forEach(el => {
+          el.addEventListener('input', checkFormValidity);
+          el.addEventListener('change', checkFormValidity);
+        });
       });
 
 
@@ -155,6 +171,8 @@
         google.script.run.withSuccessHandler(map => {
           map[currentTrip.recurringId];
         }).withFailureHandler(() => {}).getStandingOrderMap();
+
+        checkFormValidity();
       }
 
 

--- a/TripStyles.html
+++ b/TripStyles.html
@@ -101,7 +101,14 @@
     z-index: 10;
   }
 
-  .save-button:hover {
+  .save-button:disabled,
+  .save-button.disabled {
+    background-color: #ccc;
+    color: #666;
+    cursor: not-allowed;
+  }
+
+  .save-button:not(:disabled):hover {
     background-color: #155ab6;
   }
 


### PR DESCRIPTION
## Summary
- make 'Add Trip' and 'Save Trip' buttons disabled by default
- add JS helpers to enable the buttons only when required fields have values
- include the check in AddTrip and EditTrip pages and when populating form data
- style disabled buttons with muted colors and prevent hover

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68675f2c4568832fb93a83b3fac57130