### PR TITLE
Fix UTC handling for time formatting

### DIFF
--- a/EditTripPage.html
+++ b/EditTripPage.html
@@ -118,13 +118,13 @@
         if (/^\d{2}:\d{2}$/.test(dateStr)) {
           return dateStr;
         }
-        return new Date(dateStr).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        return new Date(dateStr).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' });
       }
 
       function convertISOStringToTimeInput(isoString) {
         const date = new Date(isoString);
-        const hours = String(date.getHours()).padStart(2, '0');
-        const minutes = String(date.getMinutes()).padStart(2, '0');
+        const hours = String(date.getUTCHours()).padStart(2, '0');
+        const minutes = String(date.getUTCMinutes()).padStart(2, '0');
         return `${hours}:${minutes}`;
       }
 

--- a/Helpers.js
+++ b/Helpers.js
@@ -96,7 +96,7 @@ function toTimeOnlySmart(val, { returnMillis = true } = {}) {
   // ISO 8601 string
   if (typeof val === "string" && /^\d{4}-\d{2}-\d{2}T/.test(val)) {
     const d = new Date(val);
-    const result = new Date(1899, 11, 30, d.getHours(), d.getMinutes());
+    const result = new Date(1899, 11, 30, d.getUTCHours(), d.getUTCMinutes());
     return returnMillis ? result.getTime() : result;
   }
 

--- a/SideBarSnapShots.js
+++ b/SideBarSnapShots.js
@@ -228,7 +228,7 @@ function restoreDispatchFromLog(date) {
     const toCleanTime = val => {
       if (!val || isNaN(new Date(val))) return "";
       const d = new Date(val);
-      return new Date(1899, 11, 30, d.getHours(), d.getMinutes());
+      return new Date(1899, 11, 30, d.getUTCHours(), d.getUTCMinutes());
     };
 
     row[0] = new Date(year, month - 1, day); // Local midnight (correct)

--- a/TripsPage.html
+++ b/TripsPage.html
@@ -657,7 +657,7 @@
         return dateStr;
       }
       const date = new Date(dateStr);
-      return date.valueOf() ? date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '-';
+      return date.valueOf() ? date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' }) : '-';
     }
 
     function renderTrips(trips) {


### PR DESCRIPTION
## Summary
- ensure TripsPage uses UTC when formatting times
- make EditTripPage time helpers read/write UTC values
- handle ISO time conversion in Helpers and SideBarSnapShots using UTC

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686820114d3c832f9458cf45e761c8a2