### PR TITLE
Use eye icon for past trips

### DIFF
--- a/TripsPage.html
+++ b/TripsPage.html
@@ -861,6 +861,11 @@
     card.className = "trip-card";
     card.dataset.tripId = trip.id;
     const isReturn = !!trip.returnOf;
+    const now = new Date();
+    now.setHours(0,0,0,0);
+    const tripDate = new Date(trip.date);
+    tripDate.setHours(0,0,0,0);
+    const isPastTrip = tripDate < now;
 
     card.innerHTML = `
       <div class="trip-info">
@@ -875,7 +880,7 @@
           <span class="${driverClass}">${trip.driver}</span>
           ${trip?.notes?.length ? `<span class="comment-icon" title="${trip.notes.replace(/"/g, '&quot;')}">💬</span>` : ''}
           ${isReturn ? `<span class="comment-icon" title="Show linked original trip" onclick="filterByTripId('${trip.returnOf}')">🔁 Return</span>` : ''}
-          <span class="edit-driver" onclick="editTrip('${trip.id}', '${trip.date}')">✏️</span>
+          <span class="edit-driver" onclick="editTrip('${trip.id}', '${trip.date}')">${isPastTrip ? '👁️' : '✏️'}</span>
         </div>
       </div>
       <div class="trip-time ${timeClass}">${formatTime(trip.time)}</div>


### PR DESCRIPTION
## Summary
- detect past trips based on the trip date
- show an eye icon instead of a pencil for past trips on the Trips page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68684b9fc154832f9af5dd28eb0cd548